### PR TITLE
config: 공통 클래스 생성 및 프로젝트 설정

### DIFF
--- a/.github/ISSUE_TEMPLATE/build.md
+++ b/.github/ISSUE_TEMPLATE/build.md
@@ -1,0 +1,12 @@
+---
+name: Build
+about: 빌드 작업
+title: 'build: '
+labels: [build]
+---
+
+## Issue Description
+- 
+
+## To Do
+- [ ] to do

--- a/.github/ISSUE_TEMPLATE/config.md
+++ b/.github/ISSUE_TEMPLATE/config.md
@@ -1,0 +1,12 @@
+---
+name: Config
+about: 프로젝트 설정
+title: 'config: '
+labels: [config]
+---
+
+## Issue Description
+- 
+
+## To Do
+- [ ] to do

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,19 +1,16 @@
-labels:
-  'feature':
-    - '^(feat):'
-  'fix':
-    - '^(fix):'
-  'refactor':
-    - '^(refactor):'
-  'release':
-    - '^(release):'
-  'test':
-    - '^(test):'
-  'docs':
-    - '^(docs):'
-  'chore':
-    - '^(chore):'
-  'config':
-    - '^(config):'
-  'build':
-    - '^(build):'
+feature:
+  - head-branch: ['^feat', 'feat']
+fix:
+  - head-branch: ['^fix', 'fix']
+refactor:
+  - head-branch: ['^refactor', 'refactor']
+config:
+  - head-branch: ['^config', 'config']
+test:
+  - head-branch: ['^test', 'test']
+build:
+  - head-branch: ['^build', 'build']
+chore:
+  - head-branch: ['^chore', 'chore']
+release:
+  - head-branch: ['^release', 'release']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,3 +13,7 @@ labels:
     - '^(docs):'
   'chore':
     - '^(chore):'
+  'config':
+    - '^(config):'
+  'build':
+    - '^(build):'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-  - pull_request_target
+  - pull_request
 
 jobs:
   labeler:

--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
+
 	runtimeOnly 'com.h2database:h2'
+
+	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/jobnote/common/api/ApiResponse.java
+++ b/src/main/java/com/jobnote/common/api/ApiResponse.java
@@ -1,0 +1,63 @@
+package com.jobnote.common.api;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ApiResponse<T>(
+        String code,
+        String message,
+        List<FieldErrorDetail> details,
+        T data
+) {
+
+    public static <T> ApiResponse<T> ofSuccess(ResponseCode responseCode) {
+        return ApiResponse.<T>builder()
+                .code(responseCode.getCode())
+                .message(responseCode.getMessage())
+                .build();
+    }
+
+    public static <T> ApiResponse<T> ofSuccess(ResponseCode responseCode, T data) {
+        return ApiResponse.<T>builder()
+                .code(responseCode.getCode())
+                .message(responseCode.getMessage())
+                .data(data)
+                .build();
+    }
+
+    public static <T> ApiResponse<T> ofFail(ResponseCode responseCode) {
+        return ApiResponse.<T>builder()
+                .code(responseCode.getCode())
+                .message(responseCode.getMessage())
+                .build();
+    }
+
+    public static <T> ApiResponse<T> ofFail(ResponseCode responseCode, List<FieldError> fieldErrors) {
+        return ApiResponse.<T>builder()
+                .code(responseCode.getCode())
+                .message(responseCode.getMessage())
+                .details(FieldErrorDetail.of(fieldErrors))
+                .build();
+    }
+
+    public record FieldErrorDetail(
+            String field,
+            String message
+    ) {
+
+        private static FieldErrorDetail of(FieldError fieldError) {
+            return new FieldErrorDetail(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+
+        private static List<FieldErrorDetail> of(List<FieldError> fieldErrors) {
+            return fieldErrors.stream()
+                    .map(FieldErrorDetail::of)
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/src/main/java/com/jobnote/common/api/ResponseCode.java
+++ b/src/main/java/com/jobnote/common/api/ResponseCode.java
@@ -1,0 +1,41 @@
+package com.jobnote.common.api;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ResponseCode {
+
+    // Success
+    OK(HttpStatus.OK, "2000", "요청이 성공적으로 처리되었습니다."),
+    CREATED(HttpStatus.CREATED, "2010", "리소스가 성공적으로 생성되었습니다."),
+
+    // 400 Bad Request
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "4000", "잘못된 요청입니다."),
+    INVALID_METHOD_ARGUMENT(HttpStatus.BAD_REQUEST, "4001", "입력값 유효성 검증에 실패했습니다."),
+
+    // 401 Unauthorized
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "4010", "요청 리소스에 대한 액세스 권한이 없습니다."),
+
+    // 403 Forbidden
+    FORBIDDEN(HttpStatus.FORBIDDEN, "4030", "요청 리소스에 대한 액세스가 금지되었습니다."),
+
+    // 404 Not Found
+    NOT_FOUND(HttpStatus.NOT_FOUND, "4040", "요청 리소스를 찾을 수 없습니다."),
+
+    // 405 Method Not Allowed
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "4050", "요청 메소드를 지원하지 않습니다."),
+
+    // 409 Conflict
+    CONFLICT(HttpStatus.CONFLICT, "4090", "요청이 서버의 상태와 충돌했습니다."),
+
+    // 500 Internal Server Error
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5000", "서버에 에러가 발생했습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/jobnote/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/jobnote/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.jobnote.common.exception;
+
+import com.jobnote.common.api.ResponseCode;
+import com.jobnote.common.api.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(JobNoteException.class)
+    public ResponseEntity<ApiResponse<Void>> handleJobNotException(JobNoteException e) {
+        log.error("JobNoteException: ", e);
+        ResponseCode responseCode = e.getResponseCode();
+        return new ResponseEntity<>(ApiResponse.ofFail(responseCode), responseCode.getStatus());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("MethodArgumentNotValidException: ", e);
+        ResponseCode responseCode = ResponseCode.INVALID_METHOD_ARGUMENT;
+        return new ResponseEntity<>(ApiResponse.ofFail(responseCode, e.getBindingResult().getFieldErrors()), responseCode.getStatus());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Exception: ", e);
+        ResponseCode responseCode = ResponseCode.INTERNAL_SERVER_ERROR;
+        return new ResponseEntity<>(ApiResponse.ofFail(responseCode), responseCode.getStatus());
+    }
+}

--- a/src/main/java/com/jobnote/common/exception/JobNoteException.java
+++ b/src/main/java/com/jobnote/common/exception/JobNoteException.java
@@ -1,0 +1,14 @@
+package com.jobnote.common.exception;
+
+import com.jobnote.common.api.ResponseCode;
+import lombok.Getter;
+
+@Getter
+public class JobNoteException extends RuntimeException {
+    private final ResponseCode responseCode;
+
+    public JobNoteException(ResponseCode responseCode) {
+        super(responseCode.getMessage());
+        this.responseCode = responseCode;
+    }
+}

--- a/src/main/java/com/jobnote/config/auth/SecurityConfig.java
+++ b/src/main/java/com/jobnote/config/auth/SecurityConfig.java
@@ -1,0 +1,27 @@
+package com.jobnote.config.auth;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable);
+
+        http
+                .formLogin(AbstractHttpConfigurer::disable);
+
+        http
+                .httpBasic(AbstractHttpConfigurer::disable);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/jobnote/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/jobnote/domain/common/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.jobnote.domain.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @Column(updatable = false)
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/src/main/java/com/jobnote/domain/config/JpaConfig.java
+++ b/src/main/java/com/jobnote/domain/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.jobnote.domain.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=jobnote

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  application:
+    name: jobnote
+
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true


### PR DESCRIPTION
## Resolved Issue
- close #3 

## PR Description
### 공통 클래스
- JPA 엔티티에서 공통으로 사용할 BaseTimeEntity를 만들었습니다.
- API 응답 코드를 모아놓은 ResponseCode enum을 만들었습니다.
  - 상태 코드에 맞게 새로운 코드를 추가하면 됩니다.
  - code의 앞 세자리는 그대로 유지하고, 뒷자리만 늘려나가면 됩니다. ex) 4000, 4001, ..., 40010
 - API 응답 클래스인 ApiResponse를 만들었습니다.
   - 성공 응답에는 ofSuccess() 메서드를, 실패 응답에는 ofFail() 메서드를 사용하면 됩니다.
 - 예외 핸들러 클래스인 GlobalExceptionHandler를 만들었습니다.
   - 새로운 핸들러가 필요하면 추가하면 됩니다.
 - 비즈니스 로직에서 사용할 커스텀 예외 클래스인 JobNotException을 만들었습니다.
   - ResponseCode를 활용해서 예외를 던지면 됩니다.
### 프로젝트 설정
- Spring Security 기본 로그인 방식을 차단했습니다.
- application.yml에 datasource와 jpa 설정을 추가했습니다.

## Others
- 설정 작업에 사용할 config 라벨과 CI 등 빌드 작업에 사용할 build 라벨 템플릿을 추가했습니다.
- PR Labeler에 문제가 있어 수정했습니다.
  - 브랜치명 기반으로 자동 라벨링되기 때문에, 다른 라벨을 추가해야 한다면 수동으로 추가해야 합니다.