### PR TITLE
config: 환경변수 설정 방식 변경

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,15 +11,6 @@ jobs:
     permissions:
       contents: read
 
-    env:
-      JWT_SECRET: ${{ secrets.JWT_SECRET }}
-      JWT_ACCESS_TOKEN_EXPIRATION_TIME: ${{ secrets.JWT_ACCESS_TOKEN_EXPIRATION_TIME }}
-      JWT_REFRESH_TOKEN_EXPIRATION_TIME: ${{ secrets.JWT_REFRESH_TOKEN_EXPIRATION_TIME }}
-      SPRING_MAIL_HOST: ${{ secrets.MAIL_HOST }}
-      SPRING_MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
-      SPRING_MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
-      SPRING_MAIL_PORT: ${{ secrets.MAIL_PORT }}
-
     steps:
       - uses: actions/checkout@v4
 
@@ -28,6 +19,9 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+
+      - name: Set up Application Secret YML
+        run: echo "${{ secrets.APPLICATION_SECRET }}" | base64 --decode > src/main/resources/application-secret.yml
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,4 @@ out/
 .vscode/
 
 ### Properties ###
-application-jwt.yml
-application-security.yml
-application-mail.yml
+application-secret.yml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,8 +4,8 @@ spring:
 
   profiles:
     group:
-      local: jwt, mail
-      test: jwt, mail
+      local: secret
+      test: secret
 
   datasource:
     url: jdbc:h2:mem:testdb


### PR DESCRIPTION
## Resolved Issue
- close #19 

## PR Description
- CI 워크플로를 실행하기 위해 Github Secrets에 환경 변수를 일일이 설정하는 대신, application-secret.yml을 생성하는 방식으로 변경했습니다.

> 기존 방식
```yml
env:
      JWT_SECRET: ${{ secrets.JWT_SECRET }}
      JWT_ACCESS_TOKEN_EXPIRATION_TIME: ${{ secrets.JWT_ACCESS_TOKEN_EXPIRATION_TIME }}
      JWT_REFRESH_TOKEN_EXPIRATION_TIME: ${{ secrets.JWT_REFRESH_TOKEN_EXPIRATION_TIME }}
      SPRING_MAIL_HOST: ${{ secrets.MAIL_HOST }}
      SPRING_MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
      SPRING_MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
      SPRING_MAIL_PORT: ${{ secrets.MAIL_PORT }}
```

> 변경된 방식
```yml
- name: Set up Application Secret YML
  run: echo "${{ secrets.APPLICATION_SECRET }}" | base64 --decode > src/main/resources/application-secret.yml
```

## Others
- application-secret.yml에 변경 사항이 생길 때마다 base64 인코딩을 진행하고, Github Secrets를 변경해야 합니다.