### PR TITLE
feat: 로그아웃 API 개발 

### DIFF
--- a/src/main/java/com/jobnote/auth/config/SecurityConfig.java
+++ b/src/main/java/com/jobnote/auth/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.jobnote.auth.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jobnote.auth.filter.LoginFilter;
 import com.jobnote.auth.filter.TokenAuthenticationFilter;
+import com.jobnote.auth.handler.CustomLogoutHandler;
 import com.jobnote.auth.handler.LoginFailureHandler;
 import com.jobnote.auth.handler.LoginSuccessHandler;
 import com.jobnote.auth.service.CustomOAuth2UserService;
@@ -24,6 +25,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import static com.jobnote.global.common.Constants.WHITELIST;
+import static com.jobnote.global.util.ResponseUtil.responseOk;
 
 @RequiredArgsConstructor
 @EnableWebSecurity
@@ -37,6 +39,7 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final LoginSuccessHandler loginSuccessHandler;
     private final LoginFailureHandler loginFailureHandler;
+    private final CustomLogoutHandler customLogoutHandler;
 
     @Bean
     public AuthenticationManager authenticationManager(final AuthenticationConfiguration authenticationConfiguration) throws Exception {
@@ -64,6 +67,11 @@ public class SecurityConfig {
                                 .userService(customOAuth2UserService))
                         .successHandler(loginSuccessHandler)
                         .failureHandler(loginFailureHandler));
+
+        http
+                .logout(httpSecurityLogoutConfigurer -> httpSecurityLogoutConfigurer
+                        .addLogoutHandler(customLogoutHandler)
+                        .logoutSuccessHandler(((request, response, authentication) -> responseOk(response, objectMapper))));
 
         http
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry -> authorizationManagerRequestMatcherRegistry

--- a/src/main/java/com/jobnote/auth/config/SecurityConfig.java
+++ b/src/main/java/com/jobnote/auth/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
     private final LoginSuccessHandler loginSuccessHandler;
     private final LoginFailureHandler loginFailureHandler;
     private final CustomLogoutHandler customLogoutHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public AuthenticationManager authenticationManager(final AuthenticationConfiguration authenticationConfiguration) throws Exception {
@@ -91,7 +92,7 @@ public class SecurityConfig {
 
         http
                 .exceptionHandling(httpSecurityExceptionHandlingConfigurer -> httpSecurityExceptionHandlingConfigurer
-                        .authenticationEntryPoint(new CustomAuthenticationEntryPoint(objectMapper)));
+                        .authenticationEntryPoint(customAuthenticationEntryPoint));
 
         http
                 .sessionManagement(session -> session.

--- a/src/main/java/com/jobnote/auth/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/jobnote/auth/exception/CustomAuthenticationEntryPoint.java
@@ -1,6 +1,7 @@
 package com.jobnote.auth.exception;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jobnote.domain.user.service.AuthTokenService;
 import com.jobnote.global.util.ResponseUtil;
 import com.jobnote.global.common.ResponseCode;
 import com.jobnote.global.exception.JobNoteException;
@@ -8,18 +9,27 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-import static com.jobnote.global.common.Constants.ATTRIBUTE_EXCEPTION;
+import static com.jobnote.global.common.Constants.*;
+import static com.jobnote.global.common.Constants.COOKIE_NAME_REFRESH_TOKEN;
+import static com.jobnote.global.common.ResponseCode.EXPIRED_TOKEN;
+import static com.jobnote.global.util.CookieUtil.getTokenFromCookie;
+import static com.jobnote.global.util.CookieUtil.invalidateCookie;
 
 @Slf4j
 @RequiredArgsConstructor
+@Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     private final ObjectMapper objectMapper;
+    private final AuthTokenService authTokenService;
 
     @Override
     public void commence(final HttpServletRequest request, final HttpServletResponse response, final AuthenticationException authException) throws IOException {
@@ -27,6 +37,16 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         final ResponseCode responseCode = e == null ? ResponseCode.FORBIDDEN : e.getResponseCode();
 
         log.error("AuthenticationException: ", e == null ? authException : e);
+
+        if (URI_USER_REISSUE.equals(request.getRequestURI())) {
+            response.addHeader(HttpHeaders.SET_COOKIE, invalidateCookie(COOKIE_NAME_ACCESS_TOKEN));
+            response.addHeader(HttpHeaders.SET_COOKIE, invalidateCookie(COOKIE_NAME_REFRESH_TOKEN));
+            SecurityContextHolder.clearContext();
+
+            if (EXPIRED_TOKEN.equals(responseCode)) {
+                authTokenService.invalidate(getTokenFromCookie(request, COOKIE_NAME_REFRESH_TOKEN));
+            }
+        }
 
         ResponseUtil.responseError(response, objectMapper, responseCode);
     }

--- a/src/main/java/com/jobnote/auth/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/jobnote/auth/exception/CustomAuthenticationEntryPoint.java
@@ -39,12 +39,12 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         log.error("AuthenticationException: ", e == null ? authException : e);
 
         if (URI_USER_REISSUE.equals(request.getRequestURI())) {
-            response.addHeader(HttpHeaders.SET_COOKIE, invalidateCookie(COOKIE_NAME_ACCESS_TOKEN));
-            response.addHeader(HttpHeaders.SET_COOKIE, invalidateCookie(COOKIE_NAME_REFRESH_TOKEN));
+            response.addHeader(HttpHeaders.SET_COOKIE, invalidateCookie(COOKIE_NAME_ACCESS_TOKEN).toString());
+            response.addHeader(HttpHeaders.SET_COOKIE, invalidateCookie(COOKIE_NAME_REFRESH_TOKEN).toString());
             SecurityContextHolder.clearContext();
 
             if (EXPIRED_TOKEN.equals(responseCode)) {
-                authTokenService.invalidate(getTokenFromCookie(request, COOKIE_NAME_REFRESH_TOKEN));
+                authTokenService.invalidate(getTokenFromCookie(request.getCookies(), COOKIE_NAME_REFRESH_TOKEN));
             }
         }
 

--- a/src/main/java/com/jobnote/auth/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/jobnote/auth/filter/TokenAuthenticationFilter.java
@@ -19,7 +19,7 @@ import java.util.*;
 
 import static com.jobnote.global.common.Constants.*;
 import static com.jobnote.global.common.ResponseCode.INVALID_TOKEN;
-import static com.jobnote.global.util.CookieUtil.getCookie;
+import static com.jobnote.global.util.CookieUtil.getTokenFromCookie;
 
 @RequiredArgsConstructor
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
@@ -43,19 +43,11 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private void validateRefreshToken(final HttpServletRequest request) {
-        final String refreshToken = getCookie(request, COOKIE_NAME_REFRESH_TOKEN)
-                .orElseThrow(() -> new JobNoteException(INVALID_TOKEN))
-                .getValue();
-
-        tokenProvider.validateRefreshToken(refreshToken);
+        tokenProvider.validateRefreshToken(getTokenFromCookie(request, COOKIE_NAME_REFRESH_TOKEN));
     }
 
     private void authenticate(final HttpServletRequest request) {
-        final String accessToken = getCookie(request, COOKIE_NAME_ACCESS_TOKEN)
-                .orElseThrow(() -> new JobNoteException(INVALID_TOKEN))
-                .getValue();
-
-        final String email = tokenProvider.getEmailFromPayload(accessToken)
+        final String email = tokenProvider.getEmailFromPayload(getTokenFromCookie(request, COOKIE_NAME_ACCESS_TOKEN))
                 .orElseThrow(() -> new JobNoteException(INVALID_TOKEN));
 
         setAuthentication(email);

--- a/src/main/java/com/jobnote/auth/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/jobnote/auth/filter/TokenAuthenticationFilter.java
@@ -43,11 +43,11 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private void validateRefreshToken(final HttpServletRequest request) {
-        tokenProvider.validateRefreshToken(getTokenFromCookie(request, COOKIE_NAME_REFRESH_TOKEN));
+        tokenProvider.validateRefreshToken(getTokenFromCookie(request.getCookies(), COOKIE_NAME_REFRESH_TOKEN));
     }
 
     private void authenticate(final HttpServletRequest request) {
-        final String email = tokenProvider.getEmailFromPayload(getTokenFromCookie(request, COOKIE_NAME_ACCESS_TOKEN))
+        final String email = tokenProvider.getEmailFromPayload(getTokenFromCookie(request.getCookies(), COOKIE_NAME_ACCESS_TOKEN))
                 .orElseThrow(() -> new JobNoteException(INVALID_TOKEN));
 
         setAuthentication(email);

--- a/src/main/java/com/jobnote/auth/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/jobnote/auth/handler/CustomLogoutHandler.java
@@ -1,7 +1,6 @@
 package com.jobnote.auth.handler;
 
 import com.jobnote.domain.user.service.AuthTokenService;
-import com.jobnote.global.exception.JobNoteException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -12,9 +11,8 @@ import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.stereotype.Component;
 
 import static com.jobnote.global.common.Constants.*;
-import static com.jobnote.global.common.ResponseCode.INVALID_TOKEN;
-import static com.jobnote.global.util.CookieUtil.getCookie;
-import static com.jobnote.global.util.ResponseUtil.createResponseCookie;
+import static com.jobnote.global.util.CookieUtil.getTokenFromCookie;
+import static com.jobnote.global.util.CookieUtil.invalidateCookie;
 
 @RequiredArgsConstructor
 @Component
@@ -24,18 +22,10 @@ public class CustomLogoutHandler implements LogoutHandler {
 
     @Override
     public void logout(final HttpServletRequest request, final HttpServletResponse response, final Authentication authentication) {
-        final String refreshToken = getCookie(request, COOKIE_NAME_REFRESH_TOKEN)
-                .orElseThrow(() -> new JobNoteException(INVALID_TOKEN))
-                .getValue();
+        authTokenService.invalidate(getTokenFromCookie(request, COOKIE_NAME_REFRESH_TOKEN));
 
-        authTokenService.invalidate(refreshToken);
-
-        response.addHeader(HttpHeaders.SET_COOKIE,
-                createResponseCookie(COOKIE_NAME_ACCESS_TOKEN, null, "/", 0));
-
-        response.addHeader(HttpHeaders.SET_COOKIE,
-                createResponseCookie(COOKIE_NAME_REFRESH_TOKEN, null, "/", 0));
-
+        response.addHeader(HttpHeaders.SET_COOKIE, invalidateCookie(COOKIE_NAME_ACCESS_TOKEN));
+        response.addHeader(HttpHeaders.SET_COOKIE, invalidateCookie(COOKIE_NAME_REFRESH_TOKEN));
         SecurityContextHolder.clearContext();
     }
 }

--- a/src/main/java/com/jobnote/auth/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/jobnote/auth/handler/CustomLogoutHandler.java
@@ -22,10 +22,10 @@ public class CustomLogoutHandler implements LogoutHandler {
 
     @Override
     public void logout(final HttpServletRequest request, final HttpServletResponse response, final Authentication authentication) {
-        authTokenService.invalidate(getTokenFromCookie(request, COOKIE_NAME_REFRESH_TOKEN));
+        authTokenService.invalidate(getTokenFromCookie(request.getCookies(), COOKIE_NAME_REFRESH_TOKEN));
 
-        response.addHeader(HttpHeaders.SET_COOKIE, invalidateCookie(COOKIE_NAME_ACCESS_TOKEN));
-        response.addHeader(HttpHeaders.SET_COOKIE, invalidateCookie(COOKIE_NAME_REFRESH_TOKEN));
+        response.addHeader(HttpHeaders.SET_COOKIE, invalidateCookie(COOKIE_NAME_ACCESS_TOKEN).toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, invalidateCookie(COOKIE_NAME_REFRESH_TOKEN).toString());
         SecurityContextHolder.clearContext();
     }
 }

--- a/src/main/java/com/jobnote/auth/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/jobnote/auth/handler/CustomLogoutHandler.java
@@ -1,0 +1,41 @@
+package com.jobnote.auth.handler;
+
+import com.jobnote.domain.user.service.AuthTokenService;
+import com.jobnote.global.exception.JobNoteException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+
+import static com.jobnote.global.common.Constants.*;
+import static com.jobnote.global.common.ResponseCode.INVALID_TOKEN;
+import static com.jobnote.global.util.CookieUtil.getCookie;
+import static com.jobnote.global.util.ResponseUtil.createResponseCookie;
+
+@RequiredArgsConstructor
+@Component
+public class CustomLogoutHandler implements LogoutHandler {
+
+    private final AuthTokenService authTokenService;
+
+    @Override
+    public void logout(final HttpServletRequest request, final HttpServletResponse response, final Authentication authentication) {
+        final String refreshToken = getCookie(request, COOKIE_NAME_REFRESH_TOKEN)
+                .orElseThrow(() -> new JobNoteException(INVALID_TOKEN))
+                .getValue();
+
+        authTokenService.invalidate(refreshToken);
+
+        response.addHeader(HttpHeaders.SET_COOKIE,
+                createResponseCookie(COOKIE_NAME_ACCESS_TOKEN, null, "/", 0));
+
+        response.addHeader(HttpHeaders.SET_COOKIE,
+                createResponseCookie(COOKIE_NAME_REFRESH_TOKEN, null, "/", 0));
+
+        SecurityContextHolder.clearContext();
+    }
+}

--- a/src/main/java/com/jobnote/auth/token/TokenProvider.java
+++ b/src/main/java/com/jobnote/auth/token/TokenProvider.java
@@ -7,9 +7,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Optional;
@@ -52,11 +54,12 @@ public class TokenProvider {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(CHARACTER_ENCODING);
 
-        response.addHeader(HttpHeaders.SET_COOKIE,
-                createResponseCookie(COOKIE_NAME_ACCESS_TOKEN, token.accessToken(), COOKIE_PATH_ACCESS_TOKEN, Math.toIntExact(jwtProvider.getJwtProperties().accessToken().expirationTime())));
+        ResponseCookie accessTokenCookie = createResponseCookie(COOKIE_NAME_ACCESS_TOKEN, token.accessToken(), COOKIE_PATH_ACCESS_TOKEN, Duration.ofMillis(jwtProvider.getJwtProperties().accessToken().expirationTime()));
+        ResponseCookie refreshTokenCookie = createResponseCookie(COOKIE_NAME_REFRESH_TOKEN, token.refreshToken(), COOKIE_PATH_REFRESH_TOKEN, Duration.ofMillis(jwtProvider.getJwtProperties().refreshToken().expirationTime()));
 
-        response.addHeader(HttpHeaders.SET_COOKIE,
-                createResponseCookie(COOKIE_NAME_REFRESH_TOKEN, token.refreshToken(), COOKIE_PATH_REFRESH_TOKEN, Math.toIntExact(jwtProvider.getJwtProperties().refreshToken().expirationTime())));
+        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
         response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.ofSuccess(responseCode)));
     }

--- a/src/main/java/com/jobnote/auth/token/TokenProvider.java
+++ b/src/main/java/com/jobnote/auth/token/TokenProvider.java
@@ -15,7 +15,7 @@ import java.time.ZoneId;
 import java.util.Optional;
 
 import static com.jobnote.global.common.Constants.*;
-import static com.jobnote.global.util.ResponseUtil.createResponseCookie;
+import static com.jobnote.global.util.CookieUtil.createResponseCookie;
 
 @RequiredArgsConstructor
 @Component

--- a/src/main/java/com/jobnote/domain/user/api/UserController.java
+++ b/src/main/java/com/jobnote/domain/user/api/UserController.java
@@ -9,7 +9,6 @@ import com.jobnote.domain.user.service.AuthTokenService;
 import com.jobnote.domain.user.service.UserService;
 import com.jobnote.global.common.ApiResponse;
 import com.jobnote.global.common.ResponseCode;
-import com.jobnote.global.exception.JobNoteException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -21,8 +20,7 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 
 import static com.jobnote.global.common.Constants.COOKIE_NAME_REFRESH_TOKEN;
-import static com.jobnote.global.common.ResponseCode.INVALID_TOKEN;
-import static com.jobnote.global.util.CookieUtil.getCookie;
+import static com.jobnote.global.util.CookieUtil.getTokenFromCookie;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
@@ -50,11 +48,7 @@ public class UserController {
     /* TOKEN REISSUE */
     @PostMapping("/reissue")
     public ResponseEntity<ApiResponse<Void>> tokenReissue(@LoginUser CustomPrincipal principal, final HttpServletRequest request, final HttpServletResponse response) throws IOException {
-        final String refreshToken = getCookie(request, COOKIE_NAME_REFRESH_TOKEN)
-                .orElseThrow(() -> new JobNoteException(INVALID_TOKEN))
-                .getValue();
-
-        final Token token = authTokenService.reissue(principal.getUserId(), refreshToken);
+        final Token token = authTokenService.reissue(principal.getUserId(), getTokenFromCookie(request, COOKIE_NAME_REFRESH_TOKEN));
 
         tokenProvider.responseToken(response, token);
 

--- a/src/main/java/com/jobnote/domain/user/api/UserController.java
+++ b/src/main/java/com/jobnote/domain/user/api/UserController.java
@@ -48,7 +48,7 @@ public class UserController {
     /* TOKEN REISSUE */
     @PostMapping("/reissue")
     public ResponseEntity<ApiResponse<Void>> tokenReissue(@LoginUser CustomPrincipal principal, final HttpServletRequest request, final HttpServletResponse response) throws IOException {
-        final Token token = authTokenService.reissue(principal.getUserId(), getTokenFromCookie(request, COOKIE_NAME_REFRESH_TOKEN));
+        final Token token = authTokenService.reissue(principal.getUserId(), getTokenFromCookie(request.getCookies(), COOKIE_NAME_REFRESH_TOKEN));
 
         tokenProvider.responseToken(response, token);
 

--- a/src/main/java/com/jobnote/domain/user/service/AuthTokenService.java
+++ b/src/main/java/com/jobnote/domain/user/service/AuthTokenService.java
@@ -37,10 +37,14 @@ public class AuthTokenService {
 
     @Transactional
     public Token reissue(final Long userId, final String existingRefreshToken) {
-        validateExistsRefreshToken(existingRefreshToken);
-        refreshTokenRepository.deleteByToken(existingRefreshToken);
-
+        invalidate(existingRefreshToken);
         return saveAndGetToken(userId);
+    }
+
+    @Transactional
+    public void invalidate(final String targetRefreshToken) {
+        validateExistsRefreshToken(targetRefreshToken);
+        refreshTokenRepository.deleteByToken(targetRefreshToken);
     }
 
     private Token issueToken(final String email) {
@@ -50,7 +54,7 @@ public class AuthTokenService {
         return tokenProvider.issueToken(tokenClaim);
     }
 
-    private void validateExistsRefreshToken(String existingRefreshToken) {
+    private void validateExistsRefreshToken(final String existingRefreshToken) {
         if (!refreshTokenRepository.existsByToken(existingRefreshToken)) {
             throw new JobNoteException(NOT_FOUND_REFRESH_TOKEN);
         }

--- a/src/main/java/com/jobnote/global/util/CookieUtil.java
+++ b/src/main/java/com/jobnote/global/util/CookieUtil.java
@@ -2,9 +2,9 @@ package com.jobnote.global.util;
 
 import com.jobnote.global.exception.JobNoteException;
 import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseCookie;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -12,28 +12,28 @@ import static com.jobnote.global.common.ResponseCode.INVALID_TOKEN;
 
 public class CookieUtil {
 
-    public static String getTokenFromCookie(final HttpServletRequest request, final String name) {
-        return getCookie(request, name)
+    public static String getTokenFromCookie(final Cookie[] cookies, final String name) {
+        return getCookie(cookies, name)
                 .orElseThrow(() -> new JobNoteException(INVALID_TOKEN))
                 .getValue();
     }
 
-    public static String createResponseCookie(final String name, final String value, final String path, final int maxAge) {
+    public static ResponseCookie createResponseCookie(final String name, final String value, final String path, final Duration maxAge) {
         return ResponseCookie.from(name, value)
                 .httpOnly(true)
                 .path(path)
                 .maxAge(maxAge)
                 // .secure(true) 운영 환경에서 설정
                 .sameSite(String.valueOf(org.springframework.boot.web.server.Cookie.SameSite.STRICT))
-                .build().toString();
+                .build();
     }
 
-    public static String invalidateCookie(final String name) {
-        return createResponseCookie(name, null, "/", 0);
+    public static ResponseCookie invalidateCookie(final String name) {
+        return createResponseCookie(name, "", "/", Duration.ZERO);
     }
 
-    private static Optional<Cookie> getCookie(final HttpServletRequest request, final String name) {
-        return Arrays.stream(request.getCookies())
+    private static Optional<Cookie> getCookie(final Cookie[] cookies, final String name) {
+        return Arrays.stream(cookies)
                 .filter(cookie -> name.equals(cookie.getName()))
                 .findFirst();
     }

--- a/src/main/java/com/jobnote/global/util/CookieUtil.java
+++ b/src/main/java/com/jobnote/global/util/CookieUtil.java
@@ -1,14 +1,38 @@
 package com.jobnote.global.util;
 
+import com.jobnote.global.exception.JobNoteException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseCookie;
 
 import java.util.Arrays;
 import java.util.Optional;
 
+import static com.jobnote.global.common.ResponseCode.INVALID_TOKEN;
+
 public class CookieUtil {
 
-    public static Optional<Cookie> getCookie(final HttpServletRequest request, final String name) {
+    public static String getTokenFromCookie(final HttpServletRequest request, final String name) {
+        return getCookie(request, name)
+                .orElseThrow(() -> new JobNoteException(INVALID_TOKEN))
+                .getValue();
+    }
+
+    public static String createResponseCookie(final String name, final String value, final String path, final int maxAge) {
+        return ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .path(path)
+                .maxAge(maxAge)
+                // .secure(true) 운영 환경에서 설정
+                .sameSite(String.valueOf(org.springframework.boot.web.server.Cookie.SameSite.STRICT))
+                .build().toString();
+    }
+
+    public static String invalidateCookie(final String name) {
+        return createResponseCookie(name, null, "/", 0);
+    }
+
+    private static Optional<Cookie> getCookie(final HttpServletRequest request, final String name) {
         return Arrays.stream(request.getCookies())
                 .filter(cookie -> name.equals(cookie.getName()))
                 .findFirst();

--- a/src/main/java/com/jobnote/global/util/ResponseUtil.java
+++ b/src/main/java/com/jobnote/global/util/ResponseUtil.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jobnote.global.common.ApiResponse;
 import com.jobnote.global.common.ResponseCode;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.boot.web.server.Cookie;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseCookie;
 
 import java.io.IOException;
 
@@ -27,15 +25,5 @@ public class ResponseUtil {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(CHARACTER_ENCODING);
         response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.ofSuccess(responseCode)));
-    }
-
-    public static String createResponseCookie(final String name, final String value, final String path, final int maxAge) {
-        return ResponseCookie.from(name, value)
-                .httpOnly(true)
-                .path(path)
-                .maxAge(maxAge)
-                // .secure(true) 운영 환경에서 설정
-                .sameSite(String.valueOf(Cookie.SameSite.STRICT))
-                .build().toString();
     }
 }

--- a/src/main/java/com/jobnote/global/util/ResponseUtil.java
+++ b/src/main/java/com/jobnote/global/util/ResponseUtil.java
@@ -21,6 +21,14 @@ public class ResponseUtil {
         response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.ofFail(responseCode)));
     }
 
+    public static void responseOk(final HttpServletResponse response, final ObjectMapper objectMapper) throws IOException {
+        final ResponseCode responseCode = ResponseCode.OK;
+        response.setStatus(responseCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(CHARACTER_ENCODING);
+        response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.ofSuccess(responseCode)));
+    }
+
     public static String createResponseCookie(final String name, final String value, final String path, final int maxAge) {
         return ResponseCookie.from(name, value)
                 .httpOnly(true)

--- a/src/test/java/com/jobnote/JobnoteApplicationTests.java
+++ b/src/test/java/com/jobnote/JobnoteApplicationTests.java
@@ -7,11 +7,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
 @ActiveProfiles(profiles = "test")
+@Transactional
 @SpringBootTest
 public abstract class JobnoteApplicationTests {
 

--- a/src/test/java/com/jobnote/auth/LoginFilterApplicationTest.java
+++ b/src/test/java/com/jobnote/auth/LoginFilterApplicationTest.java
@@ -3,7 +3,6 @@ package com.jobnote.auth;
 import com.jobnote.JobnoteApplicationTests;
 import com.jobnote.domain.user.domain.User;
 import com.jobnote.domain.user.dto.UserLoginRequest;
-import com.jobnote.domain.user.repository.RefreshTokenRepository;
 import com.jobnote.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,12 +22,7 @@ class LoginFilterApplicationTest extends JobnoteApplicationTests {
     private UserRepository userRepository;
 
     @Autowired
-    private RefreshTokenRepository refreshTokenRepository;
-
-    @Autowired
     private PasswordEncoder passwordEncoder;
-
-    private User savedUser;
 
     private final String LOGIN_URI = "/login";
     private final String CORRECT_EMAIL = "testCorrectEmail@test.com";
@@ -36,13 +30,7 @@ class LoginFilterApplicationTest extends JobnoteApplicationTests {
 
     @BeforeEach
     void setUp() {
-        savedUser = userRepository.save(User.signUp(CORRECT_EMAIL, passwordEncoder.encode(CORRECT_PASSWORD), "testNickname"));
-    }
-
-    @AfterEach
-    void tearDown() {
-        refreshTokenRepository.deleteAll();
-        userRepository.deleteAll();
+        userRepository.save(User.signUp(CORRECT_EMAIL, passwordEncoder.encode(CORRECT_PASSWORD), "testNickname"));
     }
 
     @Nested
@@ -85,6 +73,8 @@ class LoginFilterApplicationTest extends JobnoteApplicationTests {
                 // then
                 resultActions
                         .andExpect(status().isUnauthorized())
+                        .andExpect(cookie().doesNotExist(COOKIE_NAME_ACCESS_TOKEN))
+                        .andExpect(cookie().doesNotExist(COOKIE_NAME_REFRESH_TOKEN))
                         .andExpect(jsonPath("$.data").isEmpty())
                         .andExpect(jsonPath("$.code").value(INVALID_USERNAME_PASSWORD.getCode()));
             }
@@ -104,6 +94,8 @@ class LoginFilterApplicationTest extends JobnoteApplicationTests {
                 // then
                 resultActions
                         .andExpect(status().isUnauthorized())
+                        .andExpect(cookie().doesNotExist(COOKIE_NAME_ACCESS_TOKEN))
+                        .andExpect(cookie().doesNotExist(COOKIE_NAME_REFRESH_TOKEN))
                         .andExpect(jsonPath("$.data").isEmpty())
                         .andExpect(jsonPath("$.code").value(INVALID_USERNAME_PASSWORD.getCode()));
             }

--- a/src/test/java/com/jobnote/global/util/CookieUtilTest.java
+++ b/src/test/java/com/jobnote/global/util/CookieUtilTest.java
@@ -1,0 +1,64 @@
+package com.jobnote.global.util;
+
+import com.jobnote.global.exception.JobNoteException;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseCookie;
+
+import java.time.Duration;
+
+import static com.jobnote.global.common.Constants.COOKIE_NAME_ACCESS_TOKEN;
+import static com.jobnote.global.common.ResponseCode.INVALID_TOKEN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CookieUtilTest {
+
+    @Nested
+    @DisplayName("토큰 쿠키 조회")
+    class AccessTokenCookie {
+
+        final String accessToken = "test.access.token";
+
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            Cookie[] cookies = new Cookie[]{new Cookie(COOKIE_NAME_ACCESS_TOKEN, accessToken)};
+
+            // when
+            String result = CookieUtil.getTokenFromCookie(cookies, COOKIE_NAME_ACCESS_TOKEN);
+
+            // then
+            assertThat(result).isEqualTo(accessToken);
+        }
+
+        @Test
+        @DisplayName("실패 - 쿠키가 존재하지 않으면 INVALID_TOKEN 예외를 발생한다")
+        void fail_INVALID_TOKEN() {
+            // given
+            Cookie[] cookies = new Cookie[]{};
+
+            // when & then
+            assertThatThrownBy(() -> CookieUtil.getTokenFromCookie(cookies, COOKIE_NAME_ACCESS_TOKEN))
+                    .isInstanceOf(JobNoteException.class)
+                    .hasMessage(INVALID_TOKEN.getMessage());
+        }
+    }
+
+    @Test
+    @DisplayName("쿠키 무효화")
+    void invalidate_Cookie() {
+        // given
+
+        // when
+        ResponseCookie responseCookie = CookieUtil.invalidateCookie(COOKIE_NAME_ACCESS_TOKEN);
+
+        // then
+        assertThat(responseCookie.getValue()).isEmpty();
+        assertThat(responseCookie.getPath()).isEqualTo("/");
+        assertThat(responseCookie.getMaxAge()).isEqualTo(Duration.ZERO);
+    }
+}


### PR DESCRIPTION
## Resolved Issue
- close #24 

## PR Description
### 로그아웃 API
- Spring Security의 기본 logout을 활용했습니다. 엔드포인트는 /logout 입니다.
- LogoutHandler 인터페이스를 구현한 CustomLogoutHandler 클래스를 만들어, 로그아웃 로직을 처리했습니다.
```java
http
    .logout(httpSecurityLogoutConfigurer -> httpSecurityLogoutConfigurer
            .addLogoutHandler(customLogoutHandler)
            .logoutSuccessHandler(((request, response, authentication) -> responseOk(response, objectMapper))));

@Override
public void logout(final HttpServletRequest request, final HttpServletResponse response, final Authentication authentication) {
    authTokenService.invalidate(getTokenFromCookie(request.getCookies(), COOKIE_NAME_REFRESH_TOKEN));

    response.addHeader(HttpHeaders.SET_COOKIE, invalidateCookie(COOKIE_NAME_ACCESS_TOKEN).toString());
    response.addHeader(HttpHeaders.SET_COOKIE, invalidateCookie(COOKIE_NAME_REFRESH_TOKEN).toString());
    SecurityContextHolder.clearContext();
}
```

### 리프레시 토큰 검증 실패 시 강제 로그아웃
- 리프레시 토큰이 유효하지 않거나 만료되는 등 검증에 실패하면 강제 로그아웃 처리하도록 구현했습니다.
- TokenAuthenticationFilter에서 예외 발생 시 CustomAuthenticationEntryPoint로 넘어가기 때문에, 여기에 로그아웃 로직을 작성했습니다.
```java
if (URI_USER_REISSUE.equals(request.getRequestURI())) {
    response.addHeader(HttpHeaders.SET_COOKIE, invalidateCookie(COOKIE_NAME_ACCESS_TOKEN).toString());
    response.addHeader(HttpHeaders.SET_COOKIE, invalidateCookie(COOKIE_NAME_REFRESH_TOKEN).toString());
    SecurityContextHolder.clearContext();

    if (EXPIRED_TOKEN.equals(responseCode)) {
        authTokenService.invalidate(getTokenFromCookie(request.getCookies(), COOKIE_NAME_REFRESH_TOKEN));
    }
}
```

### 로그아웃 로직
- 로그아웃은 기본적으로 다음의 로직을 포함하도록 구현했습니다.
  - 액세스 토큰 쿠키 삭제
  - 리프레시 토큰 쿠키 삭제
  - SecurityContextHolder.clearContext()로 인증 정보 삭제
  - DB에서 리프레시 토큰 삭제

## Others