### PR TITLE
feat: 문서 관리 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
+	// AWS S3
+	implementation("software.amazon.awssdk:s3:2.32.14")
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/jobnote/domain/applicationform/api/ApplicationFormController.java
+++ b/src/main/java/com/jobnote/domain/applicationform/api/ApplicationFormController.java
@@ -1,16 +1,15 @@
 package com.jobnote.domain.applicationform.api;
 
+import com.jobnote.auth.config.LoginUser;
+import com.jobnote.auth.dto.CustomPrincipal;
 import com.jobnote.domain.applicationform.dto.ApplicationFormRequest;
 import com.jobnote.domain.applicationform.dto.ApplicationFormResponse;
 import com.jobnote.domain.applicationform.service.ApplicationFormService;
 import com.jobnote.global.common.ApiResponse;
 import com.jobnote.global.common.ResponseCode;
-import com.jobnote.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -23,17 +22,14 @@ import java.util.List;
 public class ApplicationFormController {
 
     private final ApplicationFormService applicationFormService;
-    private final UserService userService;
 
     /* CREATE */
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> createApplicationForm(
             @RequestBody @Valid final ApplicationFormRequest request,
-            @AuthenticationPrincipal final UserDetails user
+            @LoginUser final CustomPrincipal principal
     ) {
-        //todo 추후 CustomUserDetails 구현 후 User id 값으로 받아올 예정
-        Long userId = userService.getUserIdFromUserDetails(user);
-        Long savedFormId = applicationFormService.save(userId, request);
+        Long savedFormId = applicationFormService.save(principal.getUserId(), request);
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(savedFormId).toUri();
 
@@ -44,20 +40,18 @@ public class ApplicationFormController {
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<ApplicationFormResponse>> getApplicationForm(
             @PathVariable("id") final Long formId,
-            @AuthenticationPrincipal final UserDetails user
+            @LoginUser final CustomPrincipal principal
     ) {
-        Long userId = userService.getUserIdFromUserDetails(user);
-        ApplicationFormResponse form = applicationFormService.getById(userId, formId);
+        ApplicationFormResponse form = applicationFormService.getById(principal.getUserId(), formId);
 
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, form));
     }
 
     @GetMapping
     public ResponseEntity<ApiResponse<List<ApplicationFormResponse>>> getAllApplicationForms(
-            @AuthenticationPrincipal final UserDetails user
+            @LoginUser final CustomPrincipal principal
     ) {
-        Long userId = userService.getUserIdFromUserDetails(user);
-        List<ApplicationFormResponse> forms = applicationFormService.getAll(userId);
+        List<ApplicationFormResponse> forms = applicationFormService.getAll(principal.getUserId());
 
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, forms));
     }
@@ -67,10 +61,9 @@ public class ApplicationFormController {
     public ResponseEntity<ApiResponse<Void>> updateApplicationForm(
             @PathVariable("id") final Long formId,
             @Valid @RequestBody final ApplicationFormRequest request,
-            @AuthenticationPrincipal final UserDetails user
+            @LoginUser final CustomPrincipal principal
     ) {
-        Long userId = userService.getUserIdFromUserDetails(user);
-        applicationFormService.update(userId, formId, request);
+        applicationFormService.update(principal.getUserId(), formId, request);
 
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }
@@ -79,10 +72,9 @@ public class ApplicationFormController {
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> deleteApplicationForm(
             @PathVariable("id") final Long formId,
-            @AuthenticationPrincipal final UserDetails user
+            @LoginUser final CustomPrincipal principal
     ) {
-        Long userId = userService.getUserIdFromUserDetails(user);
-        applicationFormService.delete(userId, formId);
+        applicationFormService.delete(principal.getUserId(), formId);
 
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }

--- a/src/main/java/com/jobnote/domain/document/api/DocumentController.java
+++ b/src/main/java/com/jobnote/domain/document/api/DocumentController.java
@@ -17,7 +17,7 @@ import java.net.URI;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/document")
+@RequestMapping("/api/v1/documents")
 @RequiredArgsConstructor
 public class DocumentController {
 

--- a/src/main/java/com/jobnote/domain/document/api/DocumentController.java
+++ b/src/main/java/com/jobnote/domain/document/api/DocumentController.java
@@ -3,6 +3,8 @@ package com.jobnote.domain.document.api;
 import com.jobnote.auth.config.LoginUser;
 import com.jobnote.auth.dto.CustomPrincipal;
 import com.jobnote.domain.document.dto.DocumentRequest;
+import com.jobnote.domain.document.dto.DocumentResponse;
+import com.jobnote.domain.document.dto.DocumentVersionResponse;
 import com.jobnote.domain.document.service.DocumentService;
 import com.jobnote.global.common.ApiResponse;
 import com.jobnote.global.common.ResponseCode;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/document")
@@ -20,6 +23,7 @@ public class DocumentController {
 
     private final DocumentService documentService;
 
+    /* CREATE */
     @PostMapping("/upload")
     public ResponseEntity<ApiResponse<Void>> uploadNewDocument(
             @RequestBody final DocumentRequest request,
@@ -43,5 +47,36 @@ public class DocumentController {
         URI location = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(savedId).toUri();
 
         return ResponseEntity.created(location).body(ApiResponse.ofSuccess(ResponseCode.CREATED));
+    }
+
+    /* READ */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<DocumentResponse>>> getAllDocuments(
+            @LoginUser final CustomPrincipal principal
+    ) {
+        List<DocumentResponse> documents = documentService.getAll(principal.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, documents));
+    }
+
+    @GetMapping("/{documentId}")
+    public ResponseEntity<ApiResponse<List<DocumentVersionResponse>>> getAllDocumentVersions(
+            @PathVariable final Long documentId,
+            @LoginUser final CustomPrincipal principal
+    ) {
+        List<DocumentVersionResponse> documents = documentService.getAllVersions(documentId, principal.getUserId());
+
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, documents));
+    }
+
+    /* DELETE */
+    @DeleteMapping("/{documentId}")
+    public ResponseEntity<ApiResponse<Void>> deleteDocument(
+            @PathVariable final Long documentId,
+            @LoginUser final CustomPrincipal principal
+    ) {
+        documentService.deleteDocument(principal.getUserId(), documentId);
+
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }
 }

--- a/src/main/java/com/jobnote/domain/document/api/DocumentController.java
+++ b/src/main/java/com/jobnote/domain/document/api/DocumentController.java
@@ -1,0 +1,37 @@
+package com.jobnote.domain.document.api;
+
+import com.jobnote.auth.config.LoginUser;
+import com.jobnote.auth.dto.CustomPrincipal;
+import com.jobnote.domain.document.dto.DocumentRequest;
+import com.jobnote.domain.document.service.DocumentService;
+import com.jobnote.global.common.ApiResponse;
+import com.jobnote.global.common.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/v1/document")
+@RequiredArgsConstructor
+public class DocumentController {
+
+    private final DocumentService documentService;
+
+    @PostMapping("/upload")
+    public ResponseEntity<ApiResponse<Void>> uploadDocument(
+            @RequestBody DocumentRequest request,
+            @LoginUser CustomPrincipal principal
+    ) {
+        Long savedId = documentService.uploadNewDocument(principal.getUserId(), request);
+
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(savedId).toUri();
+
+        return ResponseEntity.created(location).body(ApiResponse.ofSuccess(ResponseCode.CREATED));
+    }
+}

--- a/src/main/java/com/jobnote/domain/document/api/DocumentController.java
+++ b/src/main/java/com/jobnote/domain/document/api/DocumentController.java
@@ -8,10 +8,7 @@ import com.jobnote.global.common.ApiResponse;
 import com.jobnote.global.common.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
@@ -24,11 +21,24 @@ public class DocumentController {
     private final DocumentService documentService;
 
     @PostMapping("/upload")
-    public ResponseEntity<ApiResponse<Void>> uploadDocument(
-            @RequestBody DocumentRequest request,
-            @LoginUser CustomPrincipal principal
+    public ResponseEntity<ApiResponse<Void>> uploadNewDocument(
+            @RequestBody final DocumentRequest request,
+            @LoginUser final CustomPrincipal principal
     ) {
         Long savedId = documentService.uploadNewDocument(principal.getUserId(), request);
+
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(savedId).toUri();
+
+        return ResponseEntity.created(location).body(ApiResponse.ofSuccess(ResponseCode.CREATED));
+    }
+
+    @PostMapping("/upload/{documentId}")
+    public ResponseEntity<ApiResponse<Void>> uploadNewVersionDocument(
+            @PathVariable final Long documentId,
+            @RequestBody final DocumentRequest request,
+            @LoginUser final CustomPrincipal principal
+    ) {
+        Long savedId = documentService.uploadNewVersionDocument(principal.getUserId(), documentId, request);
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(savedId).toUri();
 

--- a/src/main/java/com/jobnote/domain/document/domain/Document.java
+++ b/src/main/java/com/jobnote/domain/document/domain/Document.java
@@ -1,0 +1,46 @@
+package com.jobnote.domain.document.domain;
+
+import com.jobnote.domain.applicationform.domain.ApplicationForm;
+import com.jobnote.domain.common.BaseTimeEntity;
+import com.jobnote.domain.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "document")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Document extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "document_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private ApplicationForm applicationForm;
+
+    @Enumerated(EnumType.STRING)
+    private DocumentType type;
+
+    private String title;
+
+    @Builder
+    public Document(
+            final User user,
+            final ApplicationForm applicationForm,
+            final DocumentType documentType,
+            final String title
+    ) {
+        this.user = user;
+        this.applicationForm = applicationForm;
+        this.type = documentType;
+        this.title = title;
+    }
+}

--- a/src/main/java/com/jobnote/domain/document/domain/Document.java
+++ b/src/main/java/com/jobnote/domain/document/domain/Document.java
@@ -3,11 +3,14 @@ package com.jobnote.domain.document.domain;
 import com.jobnote.domain.applicationform.domain.ApplicationForm;
 import com.jobnote.domain.common.BaseTimeEntity;
 import com.jobnote.domain.user.domain.User;
+import com.jobnote.global.exception.JobNoteException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import static com.jobnote.global.common.ResponseCode.FORBIDDEN;
 
 @Entity
 @Getter
@@ -42,5 +45,11 @@ public class Document extends BaseTimeEntity {
         this.applicationForm = applicationForm;
         this.type = documentType;
         this.title = title;
+    }
+
+    public void validateOwner(final Long userId) {
+        if (!this.user.getId().equals(userId)) {
+            throw new JobNoteException(FORBIDDEN);
+        }
     }
 }

--- a/src/main/java/com/jobnote/domain/document/domain/DocumentType.java
+++ b/src/main/java/com/jobnote/domain/document/domain/DocumentType.java
@@ -1,0 +1,15 @@
+package com.jobnote.domain.document.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DocumentType {
+    RESUME("이력서"),
+    COVER_LETTER("자기소개서"),
+    PORTFOLIO("포트폴리오"),
+    ;
+
+    private final String description;
+}

--- a/src/main/java/com/jobnote/domain/document/domain/DocumentVersion.java
+++ b/src/main/java/com/jobnote/domain/document/domain/DocumentVersion.java
@@ -1,0 +1,46 @@
+package com.jobnote.domain.document.domain;
+
+import com.jobnote.domain.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "document_version")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DocumentVersion extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "document_version_id")
+    private Long id;
+
+    private int version;
+
+    private String fileName;
+
+    private Long fileSize;
+
+    private String fileUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Document document;
+
+    @Builder
+    public DocumentVersion(
+            final int version,
+            final String fileName,
+            final Long fileSize,
+            final String fileUrl,
+            final Document document
+    ) {
+        this.version = version;
+        this.fileName = fileName;
+        this.fileSize = fileSize;
+        this.fileUrl = fileUrl;
+        this.document = document;
+    }
+}

--- a/src/main/java/com/jobnote/domain/document/dto/DocumentRequest.java
+++ b/src/main/java/com/jobnote/domain/document/dto/DocumentRequest.java
@@ -1,0 +1,20 @@
+package com.jobnote.domain.document.dto;
+
+import com.jobnote.domain.document.domain.Document;
+import com.jobnote.domain.document.domain.DocumentType;
+import com.jobnote.domain.user.domain.User;
+
+public record DocumentRequest(
+        String fileName,
+        String fileUrl,
+        DocumentType fileType,
+        Long fileSize
+) {
+    public Document toEntity(final User user) {
+        return Document.builder()
+                .user(user)
+                .documentType(fileType)
+                .title(fileName)
+                .build();
+    }
+}

--- a/src/main/java/com/jobnote/domain/document/dto/DocumentResponse.java
+++ b/src/main/java/com/jobnote/domain/document/dto/DocumentResponse.java
@@ -1,0 +1,26 @@
+package com.jobnote.domain.document.dto;
+
+import com.jobnote.domain.document.domain.Document;
+import com.jobnote.domain.document.domain.DocumentType;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+
+@Builder(access = AccessLevel.PRIVATE)
+public record DocumentResponse(
+        Long id,
+        DocumentType type,
+        String title,
+        LocalDate lastModifiedDate
+) {
+    public static DocumentResponse from(final Document document) {
+        return DocumentResponse.builder()
+                .id(document.getId())
+                .type(document.getType())
+                .title(document.getTitle())
+                .lastModifiedDate(document.getModifiedDate().toLocalDate())
+                .build();
+    }
+}

--- a/src/main/java/com/jobnote/domain/document/dto/DocumentVersionResponse.java
+++ b/src/main/java/com/jobnote/domain/document/dto/DocumentVersionResponse.java
@@ -1,0 +1,24 @@
+package com.jobnote.domain.document.dto;
+
+import com.jobnote.domain.document.domain.DocumentVersion;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record DocumentVersionResponse(
+    Long id,
+    int version,
+    String fileName,
+    Long fileSize,
+    String fileUrl
+) {
+    public static DocumentVersionResponse from(final DocumentVersion documentVersion) {
+        return DocumentVersionResponse.builder()
+                .id(documentVersion.getId())
+                .version(documentVersion.getVersion())
+                .fileName(documentVersion.getFileName())
+                .fileSize(documentVersion.getFileSize())
+                .fileUrl(documentVersion.getFileUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/jobnote/domain/document/repository/DocumentRepository.java
+++ b/src/main/java/com/jobnote/domain/document/repository/DocumentRepository.java
@@ -1,0 +1,15 @@
+package com.jobnote.domain.document.repository;
+
+import com.jobnote.domain.document.domain.Document;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface DocumentRepository extends JpaRepository<Document, Long> {
+    /* 해당 지원서의 문서 목록 조회 */
+    @Query("select d from Document d join fetch d.applicationForm af join fetch af.user where af.user.id = :userId and af.id = :formId")
+    List<Document> findAllByUserIdAndApplicationFormId(final Long userId, final Long formId);
+
+    List<Document> findAllByUserId(final Long userId);
+}

--- a/src/main/java/com/jobnote/domain/document/repository/DocumentVersionRepository.java
+++ b/src/main/java/com/jobnote/domain/document/repository/DocumentVersionRepository.java
@@ -9,12 +9,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DocumentVersionRepository extends JpaRepository<DocumentVersion, Long> {
-    /* 해당 문서의 모든 버전 조회 */
-    List<DocumentVersion> findAllByDocumentId(final Long documentId);
-
     @Query("select MAX(v.version) from DocumentVersion v where v.document.id = :documentId")
     Optional<Integer> findMaxVersionByDocumentId(final Long documentId);
 
     @Query("select v from DocumentVersion v join fetch v.document d join d.user u where u.id = :userId and d.id = :documentId order by v.version desc")
-    List<DocumentVersionResponse> findAllByUserIdAndDocumentId(final Long userId, final Long documentId);
+    List<DocumentVersion> findAllByUserIdAndDocumentId(final Long userId, final Long documentId);
 }

--- a/src/main/java/com/jobnote/domain/document/repository/DocumentVersionRepository.java
+++ b/src/main/java/com/jobnote/domain/document/repository/DocumentVersionRepository.java
@@ -1,0 +1,11 @@
+package com.jobnote.domain.document.repository;
+
+import com.jobnote.domain.document.domain.DocumentVersion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DocumentVersionRepository extends JpaRepository<DocumentVersion, Long> {
+    /* 해당 문서의 모든 버전 조회 */
+    List<DocumentVersion> findAllByDocumentId(final Long documentId);
+}

--- a/src/main/java/com/jobnote/domain/document/repository/DocumentVersionRepository.java
+++ b/src/main/java/com/jobnote/domain/document/repository/DocumentVersionRepository.java
@@ -2,10 +2,15 @@ package com.jobnote.domain.document.repository;
 
 import com.jobnote.domain.document.domain.DocumentVersion;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DocumentVersionRepository extends JpaRepository<DocumentVersion, Long> {
     /* 해당 문서의 모든 버전 조회 */
     List<DocumentVersion> findAllByDocumentId(final Long documentId);
+
+    @Query("SELECT MAX(v.version) FROM DocumentVersion v WHERE v.document.id = :documentId")
+    Optional<Integer> findMaxVersionByDocumentId(Long documentId);
 }

--- a/src/main/java/com/jobnote/domain/document/repository/DocumentVersionRepository.java
+++ b/src/main/java/com/jobnote/domain/document/repository/DocumentVersionRepository.java
@@ -1,6 +1,7 @@
 package com.jobnote.domain.document.repository;
 
 import com.jobnote.domain.document.domain.DocumentVersion;
+import com.jobnote.domain.document.dto.DocumentVersionResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -11,6 +12,9 @@ public interface DocumentVersionRepository extends JpaRepository<DocumentVersion
     /* 해당 문서의 모든 버전 조회 */
     List<DocumentVersion> findAllByDocumentId(final Long documentId);
 
-    @Query("SELECT MAX(v.version) FROM DocumentVersion v WHERE v.document.id = :documentId")
-    Optional<Integer> findMaxVersionByDocumentId(Long documentId);
+    @Query("select MAX(v.version) from DocumentVersion v where v.document.id = :documentId")
+    Optional<Integer> findMaxVersionByDocumentId(final Long documentId);
+
+    @Query("select v from DocumentVersion v join fetch v.document d join d.user u where u.id = :userId and d.id = :documentId order by v.version desc")
+    List<DocumentVersionResponse> findAllByUserIdAndDocumentId(final Long userId, final Long documentId);
 }

--- a/src/main/java/com/jobnote/domain/document/service/DocumentService.java
+++ b/src/main/java/com/jobnote/domain/document/service/DocumentService.java
@@ -1,0 +1,41 @@
+package com.jobnote.domain.document.service;
+
+import com.jobnote.domain.document.domain.Document;
+import com.jobnote.domain.document.domain.DocumentVersion;
+import com.jobnote.domain.document.dto.DocumentRequest;
+import com.jobnote.domain.document.repository.DocumentRepository;
+import com.jobnote.domain.document.repository.DocumentVersionRepository;
+import com.jobnote.domain.user.domain.User;
+import com.jobnote.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DocumentService {
+
+    private final DocumentRepository documentRepository;
+    private final DocumentVersionRepository documentVersionRepository;
+    private final UserService userService;
+
+    @Transactional
+    public Long uploadNewDocument(Long userId, DocumentRequest request) {
+        User user = userService.getUserById(userId);
+        Document document = request.toEntity(user);
+        documentRepository.save(document);
+
+        DocumentVersion version = DocumentVersion.builder()
+                .version(1)
+                .fileName(request.fileName())
+                .fileUrl(request.fileUrl())
+                .fileSize(request.fileSize())
+                .document(document)
+                .build();
+
+        documentVersionRepository.save(version);
+
+        return document.getId();
+    }
+}

--- a/src/main/java/com/jobnote/domain/document/service/DocumentService.java
+++ b/src/main/java/com/jobnote/domain/document/service/DocumentService.java
@@ -7,9 +7,12 @@ import com.jobnote.domain.document.repository.DocumentRepository;
 import com.jobnote.domain.document.repository.DocumentVersionRepository;
 import com.jobnote.domain.user.domain.User;
 import com.jobnote.domain.user.service.UserService;
+import com.jobnote.global.exception.JobNoteException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.jobnote.global.common.ResponseCode.NOT_FOUND_DOCUMENT;
 
 @Service
 @Transactional(readOnly = true)
@@ -21,12 +24,12 @@ public class DocumentService {
     private final UserService userService;
 
     @Transactional
-    public Long uploadNewDocument(Long userId, DocumentRequest request) {
+    public Long uploadNewDocument(final Long userId, final DocumentRequest request) {
         User user = userService.getUserById(userId);
         Document document = request.toEntity(user);
         documentRepository.save(document);
 
-        DocumentVersion version = DocumentVersion.builder()
+        DocumentVersion documentVersion = DocumentVersion.builder()
                 .version(1)
                 .fileName(request.fileName())
                 .fileUrl(request.fileUrl())
@@ -34,8 +37,33 @@ public class DocumentService {
                 .document(document)
                 .build();
 
-        documentVersionRepository.save(version);
+        documentVersionRepository.save(documentVersion);
 
         return document.getId();
+    }
+
+    @Transactional
+    public Long uploadNewVersionDocument(final Long userId, final Long documentId, final DocumentRequest request) {
+        Document document = getByIdOrThrow(documentId);
+        document.validateOwner(userId);
+
+        int version = documentVersionRepository.findMaxVersionByDocumentId(documentId).orElse(1);
+        DocumentVersion documentVersion = DocumentVersion.builder()
+                .version(version + 1)
+                .fileName(request.fileName())
+                .fileUrl(request.fileUrl())
+                .fileSize(request.fileSize())
+                .document(document)
+                .build();
+
+        DocumentVersion savedDocumentVersion = documentVersionRepository.save(documentVersion);
+
+        return savedDocumentVersion.getId();
+    }
+
+    /* HELPER METHOD */
+    public Document getByIdOrThrow(final Long docId) {
+        return documentRepository.findById(docId)
+                .orElseThrow(() -> new JobNoteException(NOT_FOUND_DOCUMENT));
     }
 }

--- a/src/main/java/com/jobnote/domain/document/service/DocumentService.java
+++ b/src/main/java/com/jobnote/domain/document/service/DocumentService.java
@@ -71,7 +71,8 @@ public class DocumentService {
     }
 
     public List<DocumentVersionResponse> getAllVersions(final Long userId, final Long documentId) {
-        return documentVersionRepository.findAllByUserIdAndDocumentId(userId, documentId);
+        return documentVersionRepository.findAllByUserIdAndDocumentId(userId, documentId).stream()
+                .map(DocumentVersionResponse::from).toList();
     }
 
     @Transactional

--- a/src/main/java/com/jobnote/domain/document/service/DocumentService.java
+++ b/src/main/java/com/jobnote/domain/document/service/DocumentService.java
@@ -3,6 +3,8 @@ package com.jobnote.domain.document.service;
 import com.jobnote.domain.document.domain.Document;
 import com.jobnote.domain.document.domain.DocumentVersion;
 import com.jobnote.domain.document.dto.DocumentRequest;
+import com.jobnote.domain.document.dto.DocumentResponse;
+import com.jobnote.domain.document.dto.DocumentVersionResponse;
 import com.jobnote.domain.document.repository.DocumentRepository;
 import com.jobnote.domain.document.repository.DocumentVersionRepository;
 import com.jobnote.domain.user.domain.User;
@@ -11,6 +13,8 @@ import com.jobnote.global.exception.JobNoteException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static com.jobnote.global.common.ResponseCode.NOT_FOUND_DOCUMENT;
 
@@ -59,6 +63,26 @@ public class DocumentService {
         DocumentVersion savedDocumentVersion = documentVersionRepository.save(documentVersion);
 
         return savedDocumentVersion.getId();
+    }
+
+    public List<DocumentResponse> getAll(final Long userId) {
+        return documentRepository.findAllByUserId(userId).stream()
+                .map(DocumentResponse::from).toList();
+    }
+
+    public List<DocumentVersionResponse> getAllVersions(final Long userId, final Long documentId) {
+        return documentVersionRepository.findAllByUserIdAndDocumentId(userId, documentId);
+    }
+
+    @Transactional
+    public void deleteDocument(final Long userId, final Long documentId) {
+        Document document = getByIdOrThrow(documentId);
+        document.validateOwner(userId);
+
+        //todo s3에서 문서 삭제
+//        List<DocumentVersion> allByDocumentId = documentVersionRepository.findAllByDocumentId(document.getId());
+
+        documentRepository.delete(document);
     }
 
     /* HELPER METHOD */

--- a/src/main/java/com/jobnote/domain/schedule/api/ScheduleController.java
+++ b/src/main/java/com/jobnote/domain/schedule/api/ScheduleController.java
@@ -1,18 +1,17 @@
 package com.jobnote.domain.schedule.api;
 
+import com.jobnote.auth.config.LoginUser;
+import com.jobnote.auth.dto.CustomPrincipal;
 import com.jobnote.domain.applicationform.domain.ApplicationForm;
 import com.jobnote.domain.applicationform.service.ApplicationFormService;
 import com.jobnote.domain.schedule.dto.ScheduleRequest;
 import com.jobnote.domain.schedule.dto.ScheduleResponse;
 import com.jobnote.domain.schedule.service.ScheduleService;
-import com.jobnote.domain.user.service.UserService;
 import com.jobnote.global.common.ApiResponse;
 import com.jobnote.global.common.ResponseCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -24,7 +23,6 @@ import java.net.URI;
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
-    private final UserService userService;
     private final ApplicationFormService applicationFormService;
 
     /* CREATE */
@@ -32,12 +30,11 @@ public class ScheduleController {
     public ResponseEntity<ApiResponse<Void>> createSchedule(
             @PathVariable Long formId,
             @RequestBody @Valid final ScheduleRequest request,
-            @AuthenticationPrincipal final UserDetails user
+            @LoginUser final CustomPrincipal principal
     ) {
-        Long userId = userService.getUserIdFromUserDetails(user);
         ApplicationForm form = applicationFormService.getByIdOrThrow(formId);
 
-        Long savedScheduleId = scheduleService.save(userId, form, request);
+        Long savedScheduleId = scheduleService.save(principal.getUserId(), form, request);
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(savedScheduleId).toUri();
 
@@ -49,10 +46,9 @@ public class ScheduleController {
     public ResponseEntity<ApiResponse<ScheduleResponse>> getSchedule(
             @PathVariable Long formId,
             @PathVariable("id") final Long scheduleId,
-            @AuthenticationPrincipal final UserDetails user
+            @LoginUser final CustomPrincipal principal
     ) {
-        Long userId = userService.getUserIdFromUserDetails(user);
-        ScheduleResponse form = scheduleService.getById(userId, formId, scheduleId);
+        ScheduleResponse form = scheduleService.getById(principal.getUserId(), formId, scheduleId);
 
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, form));
     }
@@ -63,10 +59,9 @@ public class ScheduleController {
             @PathVariable Long formId,
             @PathVariable("id") final Long scheduleId,
             @Valid @RequestBody final ScheduleRequest request,
-            @AuthenticationPrincipal final UserDetails user
+            @LoginUser final CustomPrincipal principal
     ) {
-        Long userId = userService.getUserIdFromUserDetails(user);
-        scheduleService.update(userId, formId, scheduleId, request);
+        scheduleService.update(principal.getUserId(), formId, scheduleId, request);
 
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }
@@ -76,10 +71,9 @@ public class ScheduleController {
     public ResponseEntity<ApiResponse<Void>> deleteSchedule(
             @PathVariable Long formId,
             @PathVariable("id") final Long scheduleId,
-            @AuthenticationPrincipal final UserDetails user
+            @LoginUser final CustomPrincipal principal
     ) {
-        Long userId = userService.getUserIdFromUserDetails(user);
-        scheduleService.delete(userId, formId, scheduleId);
+        scheduleService.delete(principal.getUserId(), formId, scheduleId);
 
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }

--- a/src/main/java/com/jobnote/global/common/ResponseCode.java
+++ b/src/main/java/com/jobnote/global/common/ResponseCode.java
@@ -40,6 +40,7 @@ public enum ResponseCode {
     NOT_FOUND_SCHEDULE(HttpStatus.NOT_FOUND, "4043", "해당 일정을 찾을 수 없습니다."),
     NOT_FOUND_VERIFICATION_TOKEN(HttpStatus.NOT_FOUND, "4044", "해당 이메일 검증 토큰을 찾을 수 없습니다."),
     NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "4045", "해당 리프레시 토큰을 찾을 수 없습니다."),
+    NOT_FOUND_DOCUMENT(HttpStatus.NOT_FOUND, "4046", "해당 문서를 찾을 수 없습니다."),
 
     // 405 Method Not Allowed
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "4050", "요청 메소드를 지원하지 않습니다."),

--- a/src/main/java/com/jobnote/global/config/S3Config.java
+++ b/src/main/java/com/jobnote/global/config/S3Config.java
@@ -1,0 +1,45 @@
+package com.jobnote.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AwsCredentials awsCredentials() {
+        return AwsBasicCredentials.create(accessKey, secretKey);
+    }
+
+    @Bean
+    public S3Presigner s3Presigner(AwsCredentials awsCredentials) {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .build();
+    }
+
+    @Bean
+    public S3Client s3Client(AwsCredentials awsCredentials) {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/jobnote/s3/api/S3Controller.java
+++ b/src/main/java/com/jobnote/s3/api/S3Controller.java
@@ -1,0 +1,29 @@
+package com.jobnote.s3.api;
+
+import com.jobnote.auth.config.LoginUser;
+import com.jobnote.auth.dto.CustomPrincipal;
+import com.jobnote.global.common.ApiResponse;
+import com.jobnote.global.common.ResponseCode;
+import com.jobnote.s3.dto.PresignedFileRequest;
+import com.jobnote.s3.dto.PresignedFileResponse;
+import com.jobnote.s3.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/s3")
+@RequiredArgsConstructor
+public class S3Controller {
+
+    private final S3Service s3Service;
+
+    @PostMapping("/presigned")
+    public ResponseEntity<ApiResponse<PresignedFileResponse>> getPresignedUrl(
+            @RequestBody final PresignedFileRequest request,
+            @LoginUser final CustomPrincipal principal
+    ) {
+        PresignedFileResponse signedUrl = s3Service.generatePresignedFile(principal.getUserId(), request);
+        return  ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, signedUrl));
+    }
+}

--- a/src/main/java/com/jobnote/s3/dto/PresignedFileRequest.java
+++ b/src/main/java/com/jobnote/s3/dto/PresignedFileRequest.java
@@ -2,7 +2,7 @@ package com.jobnote.s3.dto;
 
 public record PresignedFileRequest(
     String fileName,
-    String fileType,
+    String contentType,
     Long fileSize
 ) {
 }

--- a/src/main/java/com/jobnote/s3/dto/PresignedFileRequest.java
+++ b/src/main/java/com/jobnote/s3/dto/PresignedFileRequest.java
@@ -1,0 +1,8 @@
+package com.jobnote.s3.dto;
+
+public record PresignedFileRequest(
+    String fileName,
+    String fileType,
+    Long fileSize
+) {
+}

--- a/src/main/java/com/jobnote/s3/dto/PresignedFileResponse.java
+++ b/src/main/java/com/jobnote/s3/dto/PresignedFileResponse.java
@@ -1,0 +1,10 @@
+package com.jobnote.s3.dto;
+
+import java.net.URL;
+
+public record PresignedFileResponse(
+        String fileName,
+        URL presignedUrl,
+        String fileUrl
+) {
+}

--- a/src/main/java/com/jobnote/s3/service/S3Service.java
+++ b/src/main/java/com/jobnote/s3/service/S3Service.java
@@ -35,7 +35,7 @@ public class S3Service {
 
     private PresignedFileResponse generatePresignedFileResponse(final Long  userId, final PresignedFileRequest request) {
         String key = createUniqueFileName(userId, request.fileName());
-        return new PresignedFileResponse(request.fileName(), generatePresignedUrl(key, request.fileType()), generateFileUrl(key));
+        return new PresignedFileResponse(request.fileName(), generatePresignedUrl(key, request.contentType()), generateFileUrl(key));
     }
 
     private URL generatePresignedUrl(final String key, final String contentType) {

--- a/src/main/java/com/jobnote/s3/service/S3Service.java
+++ b/src/main/java/com/jobnote/s3/service/S3Service.java
@@ -1,0 +1,64 @@
+package com.jobnote.s3.service;
+
+import com.jobnote.s3.dto.PresignedFileRequest;
+import com.jobnote.s3.dto.PresignedFileResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.net.URL;
+import java.time.Duration;
+import java.util.UUID;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Presigner s3Presigner;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    public PresignedFileResponse generatePresignedFile(final Long userId, final PresignedFileRequest request) {
+        return generatePresignedFileResponse(userId, request);
+    }
+
+    private PresignedFileResponse generatePresignedFileResponse(final Long  userId, final PresignedFileRequest request) {
+        String key = createUniqueFileName(userId, request.fileName());
+        return new PresignedFileResponse(request.fileName(), generatePresignedUrl(key, request.fileType()), generateFileUrl(key));
+    }
+
+    private URL generatePresignedUrl(final String key, final String contentType) {
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(contentType)
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(10))
+                .putObjectRequest(objectRequest)
+                .build();
+
+        PresignedPutObjectRequest presigned = s3Presigner.presignPutObject(presignRequest);
+        return presigned.url();
+    }
+
+    private String generateFileUrl(final String key) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, key);
+    }
+
+    private String createUniqueFileName(final Long userId, final String originalFileName) {
+        return String.format("%d/%s_%s", userId, UUID.randomUUID(), originalFileName);
+    }
+}


### PR DESCRIPTION
## Resolved Issue
- close #14 

## PR Description
- AWS S3와 연동하여 문서 관리 기능을 구현하였습니다.

### AWS S3 Presigned URL
스프링부트 서버로 직접 파일을 업로드하는 방식이 아닌, AWS의 PresignedUrl(미리서명된 URL) 기능을 이용하여 클라이언트가 직접 AWS 서버에 파일을 업로드하는 방식으로 구현하여 백엔드 서버의 부담을 줄였습니다.

사용 예시 : Postman
POST /api/v1/s3/presigned
<img width="824" height="683" alt="image" src="https://github.com/user-attachments/assets/c9878a40-8513-45cb-b71a-653b2383550b" />
업로드 할 파일명, 문서타입(contentType), 파일용량을 요청하면 서버에서 presignedUrl과 fileUrl(파일 업로드 완료 후 다운로드 할 수 있는 Url)을 반환합니다.

<img width="807" height="166" alt="image" src="https://github.com/user-attachments/assets/7601e37d-66b5-4c74-b761-cc0796a9b268" />
위의 POST에서 생성된 presignedUrl에 PUT을 이용하여 파일을 업로드합니다.

<img width="692" height="458" alt="image" src="https://github.com/user-attachments/assets/f57bb83e-8dba-4b5d-b57e-c91de64bd1bf" />
위의 POST에서 생성된 fileUrl에 GET을 이용하여 s3에 업로드된 파일을 다운로드 받습니다.

파일명은 "<유저ID>/<랜덤 UUID>_<원본 파일명>"으로 고유하게 생성됩니다.
접속 주소는 "https://<버킷명>.s3.<region명>.amazonaws.com/<파일명>" 입니다.

### 엔티티
Document : 문서의 그룹입니다. 간단하게 폴더라고 생각해도 좋을 것 같습니다.
-> 문서종류(이력서, 자기소개서, 포트폴리오), 제목 값을 저장합니다.
DocumentVersion : Document의 하위 객체이며, 문서의 여러 버전을 파일별로 저장합니다.
-> 버전, 파일명, 파일사이즈, 파일URL 값을 저장합니다.

## Others
- 개인당 용량 제한 등 조금 더 섬세한 구현이 필요해 추후 추가 예정입니다.
- 실행을 위하여 application-secret.yml 파일의 설정값이 필요합니다.
- cloud.aws.credentials.access-key
- cloud.aws.credentials.secret-key
- cloud.aws.region.static
- cloud.aws.s3.bucket