### PR TITLE
feat: 회원 정보 조회 API 개발

### DIFF
--- a/src/main/java/com/jobnote/domain/user/api/UserController.java
+++ b/src/main/java/com/jobnote/domain/user/api/UserController.java
@@ -5,6 +5,7 @@ import com.jobnote.auth.dto.CustomPrincipal;
 import com.jobnote.auth.token.Token;
 import com.jobnote.auth.token.TokenProvider;
 import com.jobnote.domain.user.dto.SocialSignUpRequest;
+import com.jobnote.domain.user.dto.UserProfileResponse;
 import com.jobnote.domain.user.dto.UserSignUpRequest;
 import com.jobnote.domain.user.service.AuthTokenService;
 import com.jobnote.domain.user.service.UserService;
@@ -61,5 +62,12 @@ public class UserController {
         tokenProvider.responseToken(response, token);
 
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
+    }
+
+    /* GET PROFILE */
+    @GetMapping("/profile")
+    public ResponseEntity<ApiResponse<UserProfileResponse>> getProfile(@LoginUser final CustomPrincipal principal) {
+        final UserProfileResponse response = userService.getProfile(principal.getUserId());
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
     }
 }

--- a/src/main/java/com/jobnote/domain/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/jobnote/domain/user/dto/UserProfileResponse.java
@@ -1,0 +1,26 @@
+package com.jobnote.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.jobnote.domain.user.domain.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record UserProfileResponse(
+        String email,
+        String nickname,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        LocalDateTime createdDate
+) {
+
+        public static UserProfileResponse from(final User user) {
+                return UserProfileResponse.builder()
+                        .email(user.getEmail())
+                        .nickname(user.getNickname())
+                        .createdDate(user.getCreatedDate())
+                        .build();
+        }
+}

--- a/src/main/java/com/jobnote/domain/user/service/UserService.java
+++ b/src/main/java/com/jobnote/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.jobnote.domain.user.service;
 import com.jobnote.domain.user.domain.User;
 import com.jobnote.domain.user.domain.VerificationToken;
 import com.jobnote.domain.user.dto.SocialSignUpRequest;
+import com.jobnote.domain.user.dto.UserProfileResponse;
 import com.jobnote.domain.user.dto.UserSignUpRequest;
 import com.jobnote.domain.user.repository.UserRepository;
 import com.jobnote.domain.user.repository.VerificationTokenRepository;
@@ -82,13 +83,18 @@ public class UserService {
         verificationTokenRepository.delete(verificationToken);
     }
 
+    public UserProfileResponse getProfile(final Long userId) {
+        final User user = getUserById(userId);
+        return UserProfileResponse.from(user);
+    }
+
     /* HELPER METHOD */
-    public User getByIdOrThrow(final Long id) {
+    private User getByIdOrThrow(final Long id) {
         return userRepository.findById(id)
                 .orElseThrow(() -> new JobNoteException(NOT_FOUND_USER));
     }
 
-    public User getByEmailOrThrow(final String email) {
+    private User getByEmailOrThrow(final String email) {
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new JobNoteException(NOT_FOUND_USER));
     }


### PR DESCRIPTION
## Resolved Issue
- close #32

## PR Description
- 회원 정보 조회 API를 개발했습니다.
- 요구사항에 따라 이메일, 닉네임, 가입일을 응답합니다.

## Others
- 특정 필드만 조회하는 Repository 메서드를 만드는 대신 getUserById 메서드를 재사용했습니다. 조회 성능보다 추후 요구사항이 변경될 때의 유연성과 재사용성을 더 높게 생각했습니다.
```java
// UserService.java
public UserProfileResponse getProfile(final Long userId) {
    final User user = getUserById(userId);
    return UserProfileResponse.from(user);
}
```
