### PR TITLE
feat: 회원 정보 수정 API 개발

### DIFF
--- a/src/main/java/com/jobnote/domain/user/api/UserController.java
+++ b/src/main/java/com/jobnote/domain/user/api/UserController.java
@@ -4,10 +4,7 @@ import com.jobnote.auth.config.LoginUser;
 import com.jobnote.auth.dto.CustomPrincipal;
 import com.jobnote.auth.token.Token;
 import com.jobnote.auth.token.TokenProvider;
-import com.jobnote.domain.user.dto.SocialSignUpRequest;
-import com.jobnote.domain.user.dto.UserAvatarRequest;
-import com.jobnote.domain.user.dto.UserProfileResponse;
-import com.jobnote.domain.user.dto.UserSignUpRequest;
+import com.jobnote.domain.user.dto.*;
 import com.jobnote.domain.user.service.AuthTokenService;
 import com.jobnote.domain.user.service.UserService;
 import com.jobnote.global.common.ApiResponse;
@@ -77,4 +74,11 @@ public class UserController {
     public ResponseEntity<ApiResponse<UserProfileResponse>> updateAvatar(@LoginUser final CustomPrincipal principal, @RequestBody @Valid UserAvatarRequest request) {
         final UserProfileResponse response = userService.updateAvatar(principal.getUserId(), request);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
-    }}
+    }
+
+    @PatchMapping("/nickname")
+    public ResponseEntity<ApiResponse<UserProfileResponse>> updateNickname(@LoginUser final CustomPrincipal principal, @RequestBody @Valid UserNicknameRequest request) {
+        final UserProfileResponse response = userService.updateNickname(principal.getUserId(), request);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+}

--- a/src/main/java/com/jobnote/domain/user/api/UserController.java
+++ b/src/main/java/com/jobnote/domain/user/api/UserController.java
@@ -5,6 +5,7 @@ import com.jobnote.auth.dto.CustomPrincipal;
 import com.jobnote.auth.token.Token;
 import com.jobnote.auth.token.TokenProvider;
 import com.jobnote.domain.user.dto.SocialSignUpRequest;
+import com.jobnote.domain.user.dto.UserAvatarRequest;
 import com.jobnote.domain.user.dto.UserProfileResponse;
 import com.jobnote.domain.user.dto.UserSignUpRequest;
 import com.jobnote.domain.user.service.AuthTokenService;
@@ -70,4 +71,10 @@ public class UserController {
         final UserProfileResponse response = userService.getProfile(principal.getUserId());
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
     }
-}
+
+    /* UPDATE PROFILE */
+    @PatchMapping("/avatar")
+    public ResponseEntity<ApiResponse<UserProfileResponse>> updateAvatar(@LoginUser final CustomPrincipal principal, @RequestBody @Valid UserAvatarRequest request) {
+        final UserProfileResponse response = userService.updateAvatar(principal.getUserId(), request);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }}

--- a/src/main/java/com/jobnote/domain/user/domain/User.java
+++ b/src/main/java/com/jobnote/domain/user/domain/User.java
@@ -68,4 +68,8 @@ public class User extends BaseTimeEntity {
         this.nickname = nickname;
         this.accept();
     }
+
+    public void updateAvatar(final String avatarUrl) {
+        this.avatarUrl = avatarUrl;
+    }
 }

--- a/src/main/java/com/jobnote/domain/user/domain/User.java
+++ b/src/main/java/com/jobnote/domain/user/domain/User.java
@@ -65,11 +65,15 @@ public class User extends BaseTimeEntity {
     }
 
     public void acceptSocial(final String nickname) {
-        this.nickname = nickname;
+        updateNickname(nickname);
         this.accept();
     }
 
     public void updateAvatar(final String avatarUrl) {
         this.avatarUrl = avatarUrl;
+    }
+
+    public void updateNickname(final String nickname) {
+        this.nickname = nickname;
     }
 }

--- a/src/main/java/com/jobnote/domain/user/dto/UserAvatarRequest.java
+++ b/src/main/java/com/jobnote/domain/user/dto/UserAvatarRequest.java
@@ -1,5 +1,8 @@
 package com.jobnote.domain.user.dto;
 
+import lombok.Builder;
+
+@Builder
 public record UserAvatarRequest(
         String avatarUrl
 ) {

--- a/src/main/java/com/jobnote/domain/user/dto/UserAvatarRequest.java
+++ b/src/main/java/com/jobnote/domain/user/dto/UserAvatarRequest.java
@@ -1,0 +1,6 @@
+package com.jobnote.domain.user.dto;
+
+public record UserAvatarRequest(
+        String avatarUrl
+) {
+}

--- a/src/main/java/com/jobnote/domain/user/dto/UserNicknameRequest.java
+++ b/src/main/java/com/jobnote/domain/user/dto/UserNicknameRequest.java
@@ -1,0 +1,12 @@
+package com.jobnote.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record UserNicknameRequest(
+
+        @NotBlank(message = "닉네임은 비어있을 수 없습니다.")
+        String nickname
+) {
+}

--- a/src/main/java/com/jobnote/domain/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/jobnote/domain/user/dto/UserProfileResponse.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 public record UserProfileResponse(
         String email,
         String nickname,
+        String avatarUrl,
 
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         LocalDateTime createdDate
@@ -20,6 +21,7 @@ public record UserProfileResponse(
                 return UserProfileResponse.builder()
                         .email(user.getEmail())
                         .nickname(user.getNickname())
+                        .avatarUrl(user.getAvatarUrl())
                         .createdDate(user.getCreatedDate())
                         .build();
         }

--- a/src/main/java/com/jobnote/domain/user/service/UserService.java
+++ b/src/main/java/com/jobnote/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.jobnote.domain.user.service;
 import com.jobnote.domain.user.domain.User;
 import com.jobnote.domain.user.domain.VerificationToken;
 import com.jobnote.domain.user.dto.SocialSignUpRequest;
+import com.jobnote.domain.user.dto.UserAvatarRequest;
 import com.jobnote.domain.user.dto.UserProfileResponse;
 import com.jobnote.domain.user.dto.UserSignUpRequest;
 import com.jobnote.domain.user.repository.UserRepository;
@@ -83,8 +84,16 @@ public class UserService {
         verificationTokenRepository.delete(verificationToken);
     }
 
+    /* GET PROFILE */
     public UserProfileResponse getProfile(final Long userId) {
         final User user = getUserById(userId);
+        return UserProfileResponse.from(user);
+    }
+
+    /* UPDATE PROFILE */
+    public UserProfileResponse updateAvatar(final Long userId, final UserAvatarRequest request) {
+        final User user = getUserById(userId);
+        user.updateAvatar(request.avatarUrl());
         return UserProfileResponse.from(user);
     }
 

--- a/src/main/java/com/jobnote/domain/user/service/UserService.java
+++ b/src/main/java/com/jobnote/domain/user/service/UserService.java
@@ -91,6 +91,7 @@ public class UserService {
     }
 
     /* UPDATE PROFILE */
+    @Transactional
     public UserProfileResponse updateAvatar(final Long userId, final UserAvatarRequest request) {
         final User user = getUserById(userId);
         user.updateAvatar(request.avatarUrl());

--- a/src/main/java/com/jobnote/domain/user/service/UserService.java
+++ b/src/main/java/com/jobnote/domain/user/service/UserService.java
@@ -2,10 +2,7 @@ package com.jobnote.domain.user.service;
 
 import com.jobnote.domain.user.domain.User;
 import com.jobnote.domain.user.domain.VerificationToken;
-import com.jobnote.domain.user.dto.SocialSignUpRequest;
-import com.jobnote.domain.user.dto.UserAvatarRequest;
-import com.jobnote.domain.user.dto.UserProfileResponse;
-import com.jobnote.domain.user.dto.UserSignUpRequest;
+import com.jobnote.domain.user.dto.*;
 import com.jobnote.domain.user.repository.UserRepository;
 import com.jobnote.domain.user.repository.VerificationTokenRepository;
 import com.jobnote.global.config.properties.AppProperties;
@@ -95,6 +92,14 @@ public class UserService {
     public UserProfileResponse updateAvatar(final Long userId, final UserAvatarRequest request) {
         final User user = getUserById(userId);
         user.updateAvatar(request.avatarUrl());
+        return UserProfileResponse.from(user);
+    }
+
+    @Transactional
+    public UserProfileResponse updateNickname(final Long userId, final UserNicknameRequest request) {
+        validateDuplicatedNickname(request.nickname());
+        final User user = getUserById(userId);
+        user.updateNickname(request.nickname());
         return UserProfileResponse.from(user);
     }
 

--- a/src/test/java/com/jobnote/domain/user/domain/UserTest.java
+++ b/src/test/java/com/jobnote/domain/user/domain/UserTest.java
@@ -49,7 +49,7 @@ class UserTest {
 
     @Test
     @DisplayName("회원의 프로필 이미지를 수정한다")
-    void socialSignUp() {
+    void updateAvatar() {
         // given
         final User user = User.signUp("testEmail@test.com", "testPassword", "testNickname");
         final User socialUser = User.socialSignUp("testEmail@test.com", "testSocailEmail@test.com", SocialProvider.GOOGLE, "testSocialId");
@@ -63,4 +63,22 @@ class UserTest {
         assertThat(user.getAvatarUrl()).isEqualTo(updatedAvatarUrl);
         assertThat(socialUser.getAvatarUrl()).isEqualTo(updatedAvatarUrl);
     }
+
+    @Test
+    @DisplayName("회원의 닉네임을 수정한다")
+    void updateNickname() {
+        // given
+        final User user = User.signUp("testEmail@test.com", "testPassword", "testNickname");
+        final User socialUser = User.socialSignUp("testEmail@test.com", "testSocailEmail@test.com", SocialProvider.GOOGLE, "testSocialId");
+        final String updatedNickname = "updatedNickname";
+
+        // when
+        user.updateNickname(updatedNickname);
+        socialUser.updateNickname(updatedNickname);
+
+        // then
+        assertThat(user.getNickname()).isEqualTo(updatedNickname);
+        assertThat(socialUser.getNickname()).isEqualTo(updatedNickname);
+    }
+
 }

--- a/src/test/java/com/jobnote/domain/user/domain/UserTest.java
+++ b/src/test/java/com/jobnote/domain/user/domain/UserTest.java
@@ -8,14 +8,59 @@ import static org.assertj.core.api.Assertions.assertThat;
 class UserTest {
 
     @Test
-    @DisplayName("회원가입 시 Role은 GUEST(임시 회원)이다")
+    @DisplayName("회원가입 시 Role은 GUEST(임시 회원)이다.")
     void signUp_UserRole_GUEST() {
         // given
 
         // when
-        User user = User.signUp("testEmail@test.com", "testPassword", "testNickname");
+        final User user = User.signUp("testEmail@test.com", "testPassword", "testNickname");
 
         // then
         assertThat(user.getRole()).isEqualTo(UserRole.GUEST);
+    }
+
+    @Test
+    @DisplayName("자체 로그인 회원을 accept시 Role은 MEMBER가 된다.")
+    void signUp_accept() {
+        // given
+        final User user = User.signUp("testEmail@test.com", "testPassword", "testNickname");
+
+        // when
+        user.accept();
+
+        // then
+        assertThat(user.getRole()).isEqualTo(UserRole.MEMBER);
+    }
+
+    @Test
+    @DisplayName("소셜 로그인 회원을 accept시 닉네임 업데이트와 함께 Role은 MEMBER가 된다.")
+    void socialSignUp_accept() {
+        // given
+        final User user = User.socialSignUp("testEmail@test.com", "testSocailEmail@test.com", SocialProvider.GOOGLE, "testSocialId");
+        final String nickname = "testNickname";
+
+        // when
+        user.acceptSocial(nickname);
+
+        // then
+        assertThat(user.getRole()).isEqualTo(UserRole.MEMBER);
+        assertThat(user.getNickname()).isEqualTo(nickname);
+    }
+
+    @Test
+    @DisplayName("회원의 프로필 이미지를 수정한다")
+    void socialSignUp() {
+        // given
+        final User user = User.signUp("testEmail@test.com", "testPassword", "testNickname");
+        final User socialUser = User.socialSignUp("testEmail@test.com", "testSocailEmail@test.com", SocialProvider.GOOGLE, "testSocialId");
+        final String updatedAvatarUrl = "updatedAvatarUrl";
+
+        // when
+        user.updateAvatar(updatedAvatarUrl);
+        socialUser.updateAvatar(updatedAvatarUrl);
+
+        // then
+        assertThat(user.getAvatarUrl()).isEqualTo(updatedAvatarUrl);
+        assertThat(socialUser.getAvatarUrl()).isEqualTo(updatedAvatarUrl);
     }
 }

--- a/src/test/java/com/jobnote/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/jobnote/domain/user/service/UserServiceTest.java
@@ -4,6 +4,7 @@ import com.jobnote.ServiceUnitTest;
 import com.jobnote.domain.user.domain.User;
 import com.jobnote.domain.user.domain.VerificationToken;
 import com.jobnote.domain.user.dto.UserAvatarRequest;
+import com.jobnote.domain.user.dto.UserNicknameRequest;
 import com.jobnote.domain.user.dto.UserProfileResponse;
 import com.jobnote.domain.user.dto.UserSignUpRequest;
 import com.jobnote.domain.user.repository.UserRepository;
@@ -136,6 +137,51 @@ class UserServiceTest extends ServiceUnitTest {
     }
 
     @Nested
+    @DisplayName("닉네임 업데이트")
+    class UpdateNickname {
+        @Test
+        @DisplayName("성공 - 닉네임만 업데이트된다.")
+        void success() {
+            // given
+            final Long userId = 1L;
+            final String existingEmail = "testEmail@test.com";
+            final String existingPassword = "testPassword";
+            final String existingNickname = "testNickname";
+            final User user = User.signUp(existingEmail, existingPassword, existingNickname);
+
+            final String updatedNickname = "updatedNickname";
+            final UserNicknameRequest request = UserNicknameRequest.builder().nickname(updatedNickname).build();
+
+            given(userRepository.existsByNickname(updatedNickname)).willReturn(false);
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+            // when
+            final UserProfileResponse result = userService.updateNickname(userId, request);
+
+            // then
+            assertThat(result.email()).isEqualTo(existingEmail);
+            assertThat(result.nickname()).isEqualTo(updatedNickname);
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 존재하는 닉네임이면 예외가 발생한다.")
+        void fail_DuplicatedNickname() {
+            // given
+            final Long userId = 1L;
+            final String updatedNickname = "updatedNickname";
+            final UserNicknameRequest request = UserNicknameRequest.builder().nickname(updatedNickname).build();
+
+            given(userRepository.existsByNickname(updatedNickname)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> userService.updateNickname(userId, request))
+                    .isInstanceOf(JobNoteException.class)
+                    .hasMessage(DUPLICATED_USER_NICKNAME.getMessage());
+            then(userRepository).should(never()).findById(userId);
+        }
+    }
+
+    @Nested
     @DisplayName("id로 회원 조회")
     class GetUser {
         @Test
@@ -151,7 +197,7 @@ class UserServiceTest extends ServiceUnitTest {
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
             // when
-            User result = userService.getUserById(userId);
+            final User result = userService.getUserById(userId);
 
             // then
             assertThat(result).isEqualTo(user);

--- a/src/test/java/com/jobnote/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/jobnote/domain/user/service/UserServiceTest.java
@@ -3,9 +3,12 @@ package com.jobnote.domain.user.service;
 import com.jobnote.ServiceUnitTest;
 import com.jobnote.domain.user.domain.User;
 import com.jobnote.domain.user.domain.VerificationToken;
+import com.jobnote.domain.user.dto.UserAvatarRequest;
+import com.jobnote.domain.user.dto.UserProfileResponse;
 import com.jobnote.domain.user.dto.UserSignUpRequest;
 import com.jobnote.domain.user.repository.UserRepository;
 import com.jobnote.domain.user.repository.VerificationTokenRepository;
+import com.jobnote.global.common.ResponseCode;
 import com.jobnote.global.config.properties.AppProperties;
 import com.jobnote.global.exception.JobNoteException;
 import com.jobnote.mail.MailService;
@@ -18,9 +21,11 @@ import org.mockito.Mock;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static com.jobnote.global.common.ResponseCode.DUPLICATED_USER_EMAIL;
 import static com.jobnote.global.common.ResponseCode.DUPLICATED_USER_NICKNAME;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
@@ -73,7 +78,7 @@ class UserServiceTest extends ServiceUnitTest {
         @DisplayName("실패 - 이메일 중복")
         void fail_DuplicatedEmail() {
             // given
-            UserSignUpRequest request = new UserSignUpRequest("testEmail@test.com", "testPassword", "testNickname");
+            final UserSignUpRequest request = new UserSignUpRequest("testEmail@test.com", "testPassword", "testNickname");
             given(userRepository.existsByEmail(request.email())).willReturn(true);
 
             // when & then
@@ -89,7 +94,7 @@ class UserServiceTest extends ServiceUnitTest {
         @DisplayName("실패 - 닉네임 중복")
         void fail_DuplicatedNickname() {
             // given
-            UserSignUpRequest request = new UserSignUpRequest("testEmail@test.com", "testPassword", "testNickname");
+            final UserSignUpRequest request = new UserSignUpRequest("testEmail@test.com", "testPassword", "testNickname");
             given(userRepository.existsByNickname(request.nickname())).willReturn(true);
 
             // when & then
@@ -99,6 +104,70 @@ class UserServiceTest extends ServiceUnitTest {
 
             then(userRepository).should().existsByNickname(request.nickname());
             then(userRepository).should(never()).save(any(User.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("프로필 이미지 업데이트")
+    class UpdateAvatar {
+        @Test
+        @DisplayName("성공 - 프로필 이미지만 업데이트된다.")
+        void success() {
+            // given
+            final Long userId = 1L;
+            final String existingEmail = "testEmail@test.com";
+            final String existingPassword = "testPassword";
+            final String existingNickname = "testNickname";
+            final User user = User.signUp(existingEmail, existingPassword, existingNickname);
+
+            final String updatedAvatarUrl = "updatedAvatarUrl";
+            final UserAvatarRequest request = UserAvatarRequest.builder().avatarUrl(updatedAvatarUrl).build();
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+            // when
+            final UserProfileResponse result = userService.updateAvatar(userId, request);
+
+            // then
+            assertThat(result.avatarUrl()).isEqualTo(updatedAvatarUrl);
+            assertThat(result.email()).isEqualTo(existingEmail);
+            assertThat(result.nickname()).isEqualTo(existingNickname);
+        }
+    }
+
+    @Nested
+    @DisplayName("id로 회원 조회")
+    class GetUser {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            final Long userId = 1L;
+            final String email = "testEmail@test.com";
+            final String password = "testPassword";
+            final String nickname = "testNickname";
+            final User user = User.signUp(email, password, nickname);
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+            // when
+            User result = userService.getUserById(userId);
+
+            // then
+            assertThat(result).isEqualTo(user);
+        }
+
+        @Test
+        @DisplayName("실패 - 회원이 존재하지 않는다.")
+        void fail_NotExistingUser() {
+            // given
+            final Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> userService.getUserById(userId))
+                    .isInstanceOf(JobNoteException.class)
+                    .hasMessage(ResponseCode.NOT_FOUND_USER.getMessage());
         }
     }
 }


### PR DESCRIPTION
## Resolved Issue
- close #34 

## PR Description
- 프로필 이미지 수정 API와 닉네임 수정 API를 개발했습니다.
- 닉네임은 필수 입력값이고 프로필 이미지는 필수 입력값이 아니기 때문에 요청 DTO와 메서드 모두 따로 만들었습니다.

## Others
- 업로드와 마찬가지로 S3에서의 이미지 삭제도 프론트에서 처리하는 것으로 간주했습니다.