### PR TITLE
feat: 비밀번호 재설정 API 개발

### DIFF
--- a/src/main/java/com/jobnote/auth/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/jobnote/auth/filter/TokenAuthenticationFilter.java
@@ -15,7 +15,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.*;
 
 import static com.jobnote.global.common.Constants.*;
 import static com.jobnote.global.common.ResponseCode.INVALID_TOKEN;
@@ -61,6 +60,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(final HttpServletRequest request) {
-        return new HashSet<>(List.of(WHITELIST)).contains(request.getRequestURI());
+        return TOKEN_FILTER_WHITELIST.stream()
+                .anyMatch((path) -> request.getRequestURI().startsWith(path));
     }
 }

--- a/src/main/java/com/jobnote/auth/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/jobnote/auth/filter/TokenAuthenticationFilter.java
@@ -61,6 +61,6 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(final HttpServletRequest request) {
         return TOKEN_FILTER_WHITELIST.stream()
-                .anyMatch((path) -> request.getRequestURI().startsWith(path));
+                .anyMatch(path -> request.getRequestURI().startsWith(path));
     }
 }

--- a/src/main/java/com/jobnote/domain/user/controller/UserController.java
+++ b/src/main/java/com/jobnote/domain/user/controller/UserController.java
@@ -1,4 +1,4 @@
-package com.jobnote.domain.user.api;
+package com.jobnote.domain.user.controller;
 
 import com.jobnote.auth.config.LoginUser;
 import com.jobnote.auth.dto.CustomPrincipal;

--- a/src/main/java/com/jobnote/domain/user/controller/UserController.java
+++ b/src/main/java/com/jobnote/domain/user/controller/UserController.java
@@ -88,4 +88,10 @@ public class UserController {
         userService.sendResetPasswordEmail(request, LocalDateTime.now().plusDays(1));
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }
+
+    @GetMapping("/reset-password/verify")
+    public ResponseEntity<ApiResponse<Void>> verifyResetPasswordEmail(@RequestParam("token") final String token) {
+        userService.verifyResetPasswordEmail(token, LocalDateTime.now());
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
+    }
 }

--- a/src/main/java/com/jobnote/domain/user/controller/UserController.java
+++ b/src/main/java/com/jobnote/domain/user/controller/UserController.java
@@ -94,4 +94,10 @@ public class UserController {
         userService.verifyResetPasswordEmail(token, LocalDateTime.now());
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }
+
+    @PatchMapping("/reset-password")
+    public ResponseEntity<ApiResponse<Void>> resetPassword(@RequestBody @Valid final UserResetPasswordRequest request, @RequestParam("token") final String token) {
+        userService.resetPassword(request, token);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
+    }
 }

--- a/src/main/java/com/jobnote/domain/user/controller/UserController.java
+++ b/src/main/java/com/jobnote/domain/user/controller/UserController.java
@@ -71,14 +71,21 @@ public class UserController {
 
     /* UPDATE PROFILE */
     @PatchMapping("/avatar")
-    public ResponseEntity<ApiResponse<UserProfileResponse>> updateAvatar(@LoginUser final CustomPrincipal principal, @RequestBody @Valid UserAvatarRequest request) {
+    public ResponseEntity<ApiResponse<UserProfileResponse>> updateAvatar(@LoginUser final CustomPrincipal principal, @RequestBody @Valid final UserAvatarRequest request) {
         final UserProfileResponse response = userService.updateAvatar(principal.getUserId(), request);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
     }
 
     @PatchMapping("/nickname")
-    public ResponseEntity<ApiResponse<UserProfileResponse>> updateNickname(@LoginUser final CustomPrincipal principal, @RequestBody @Valid UserNicknameRequest request) {
+    public ResponseEntity<ApiResponse<UserProfileResponse>> updateNickname(@LoginUser final CustomPrincipal principal, @RequestBody @Valid final UserNicknameRequest request) {
         final UserProfileResponse response = userService.updateNickname(principal.getUserId(), request);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK, response));
+    }
+
+    /* RESET PASSWORD */
+    @PostMapping("/reset-password/email")
+    public ResponseEntity<ApiResponse<Void>> sendResetPasswordEmail(@RequestBody @Valid final UserResetPasswordEmailRequest request) {
+        userService.sendResetPasswordEmail(request, LocalDateTime.now().plusDays(1));
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }
 }

--- a/src/main/java/com/jobnote/domain/user/domain/User.java
+++ b/src/main/java/com/jobnote/domain/user/domain/User.java
@@ -76,4 +76,8 @@ public class User extends BaseTimeEntity {
     public void updateNickname(final String nickname) {
         this.nickname = nickname;
     }
+
+    public void resetPassword(final String newPassword) {
+        this.password = newPassword;
+    }
 }

--- a/src/main/java/com/jobnote/domain/user/dto/UserResetPasswordEmailRequest.java
+++ b/src/main/java/com/jobnote/domain/user/dto/UserResetPasswordEmailRequest.java
@@ -1,0 +1,10 @@
+package com.jobnote.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+
+public record UserResetPasswordEmailRequest(
+
+        @Email(message = "형식에 맞는 이메일을 입력해주세요.")
+        String email
+) {
+}

--- a/src/main/java/com/jobnote/domain/user/dto/UserResetPasswordRequest.java
+++ b/src/main/java/com/jobnote/domain/user/dto/UserResetPasswordRequest.java
@@ -1,0 +1,10 @@
+package com.jobnote.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserResetPasswordRequest(
+
+        @NotBlank(message = "비밀번호는 비어있을 수 없습니다.")
+        String newPassword
+) {
+}

--- a/src/main/java/com/jobnote/domain/user/event/EmailVerificationEvent.java
+++ b/src/main/java/com/jobnote/domain/user/event/EmailVerificationEvent.java
@@ -1,7 +1,7 @@
 package com.jobnote.domain.user.event;
 
-public record SignUpEvent(
+public record EmailVerificationEvent(
         String toEmail,
-        String verificationToken
+        String token
 ) {
 }

--- a/src/main/java/com/jobnote/domain/user/event/EmailVerificationEvent.java
+++ b/src/main/java/com/jobnote/domain/user/event/EmailVerificationEvent.java
@@ -1,7 +1,50 @@
 package com.jobnote.domain.user.event;
 
+import com.jobnote.global.config.properties.AppProperties;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.function.Function;
+
+@Builder(access = AccessLevel.PRIVATE)
 public record EmailVerificationEvent(
         String toEmail,
-        String token
+        String token,
+        EmailType emailType
 ) {
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum EmailType {
+        SIGN_UP("회원가입", AppProperties.EmailVerificationPathProperties::signUp),
+        RESET_PASSWORD("비밀번호 재설정", AppProperties.EmailVerificationPathProperties::resetPassword),
+        ;
+
+        private final String title;
+        private final Function<AppProperties.EmailVerificationPathProperties, String> pathFunction;
+
+        public String getPath(final AppProperties.EmailVerificationPathProperties pathProperties) {
+            return pathFunction.apply(pathProperties);
+        }
+    }
+
+    public static EmailVerificationEvent signUp(final String toEmail, final String token) {
+        return EmailVerificationEvent.of(toEmail, token)
+                .emailType(EmailType.SIGN_UP)
+                .build();
+    }
+
+    public static EmailVerificationEvent resetPassword(final String toEmail, final String token) {
+        return EmailVerificationEvent.of(toEmail, token)
+                .emailType(EmailType.RESET_PASSWORD)
+                .build();
+    }
+
+    private static EmailVerificationEventBuilder of(final String toEmail, final String token) {
+        return EmailVerificationEvent.builder()
+                .toEmail(toEmail)
+                .token(token);
+    }
 }

--- a/src/main/java/com/jobnote/domain/user/event/EmailVerificationEventListener.java
+++ b/src/main/java/com/jobnote/domain/user/event/EmailVerificationEventListener.java
@@ -22,7 +22,6 @@ public class EmailVerificationEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onEvent(final EmailVerificationEvent emailVerificationEvent) {
         final MailMessageDto mailMessageDto = createMailMessageDto(emailVerificationEvent);
-        System.out.println(mailMessageDto);
         mailService.sendMail(mailMessageDto);
     }
 

--- a/src/main/java/com/jobnote/domain/user/event/EmailVerificationEventListener.java
+++ b/src/main/java/com/jobnote/domain/user/event/EmailVerificationEventListener.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 @RequiredArgsConstructor
 @Component
-public class SignUpEventListener {
+public class EmailVerificationEventListener {
 
     private final MailService mailService;
     private final AppProperties appProperties;
@@ -21,23 +21,24 @@ public class SignUpEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onEvent(final EmailVerificationEvent emailVerificationEvent) {
-        final MailMessageDto mailMessageDto = createMailMessageDto(emailVerificationEvent.toEmail(), emailVerificationEvent.token());
+        final MailMessageDto mailMessageDto = createMailMessageDto(emailVerificationEvent);
+        System.out.println(mailMessageDto);
         mailService.sendMail(mailMessageDto);
     }
 
-    private MailMessageDto createMailMessageDto(final String email, final String verificationToken) {
-        final String link = appProperties.baseUrl() + appProperties.emailVerificationPath().signUp() + "?token=" + verificationToken;
-        final String subject = "JobNote 회원가입 이메일 인증";
+    private MailMessageDto createMailMessageDto(final EmailVerificationEvent event) {
+        final String link = appProperties.baseUrl() + event.emailType().getPath(appProperties.emailVerificationPath()) + "?token=" + event.token();
+        final String subject = String.format("JobNote %s 이메일 인증", event.emailType().getTitle());
         final String text = String.format("""
                 JobNote를 이용해주셔서 감사합니다.
-                아래 이메일 인증 링크를 클릭하여 회원가입을 완료해 주세요.
+                아래 이메일 인증 링크를 클릭하여 %s을 완료해 주세요.
                 감사합니다.
                 %s
-                """, link);
+                """, event.emailType().getTitle(), link);
 
         return MailMessageDto.builder()
                 .from(fromEmail)
-                .to(email)
+                .to(event.toEmail())
                 .subject(subject)
                 .text(text)
                 .build();

--- a/src/main/java/com/jobnote/domain/user/event/SignUpEventListener.java
+++ b/src/main/java/com/jobnote/domain/user/event/SignUpEventListener.java
@@ -26,7 +26,7 @@ public class SignUpEventListener {
     }
 
     private MailMessageDto createMailMessageDto(final String email, final String verificationToken) {
-        final String link = appProperties.baseUrl() + appProperties.emailVerificationPath() + "?token=" + verificationToken;
+        final String link = appProperties.baseUrl() + appProperties.emailVerificationPath().signUp() + "?token=" + verificationToken;
         final String subject = "JobNote 회원가입 이메일 인증";
         final String text = String.format("""
                 JobNote를 이용해주셔서 감사합니다.

--- a/src/main/java/com/jobnote/domain/user/event/SignUpEventListener.java
+++ b/src/main/java/com/jobnote/domain/user/event/SignUpEventListener.java
@@ -20,8 +20,8 @@ public class SignUpEventListener {
     private String fromEmail;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void onEvent(final SignUpEvent signUpEvent) {
-        final MailMessageDto mailMessageDto = createMailMessageDto(signUpEvent.toEmail(), signUpEvent.verificationToken());
+    public void onEvent(final EmailVerificationEvent emailVerificationEvent) {
+        final MailMessageDto mailMessageDto = createMailMessageDto(emailVerificationEvent.toEmail(), emailVerificationEvent.token());
         mailService.sendMail(mailMessageDto);
     }
 

--- a/src/main/java/com/jobnote/domain/user/service/UserService.java
+++ b/src/main/java/com/jobnote/domain/user/service/UserService.java
@@ -101,8 +101,17 @@ public class UserService {
         eventPublisher.publishEvent(EmailVerificationEvent.resetPassword(user.getEmail(), savedVerificationToken.getToken()));
     }
 
+    @Transactional
     public void verifyResetPasswordEmail(final String token, final LocalDateTime currentDate) {
         verificationTokenService.verifyToken(token, currentDate);
+    }
+
+    @Transactional
+    public void resetPassword(final UserResetPasswordRequest request, final String token) {
+        final VerificationToken verificationToken = verificationTokenService.getVerificationTokenByToken(token);
+        verificationToken.validateVerified();
+        final User user = verificationToken.getUser();
+        user.resetPassword(passwordEncoder.encode(request.newPassword()));
     }
 
     /* HELPER METHOD */

--- a/src/main/java/com/jobnote/domain/user/service/UserService.java
+++ b/src/main/java/com/jobnote/domain/user/service/UserService.java
@@ -99,8 +99,8 @@ public class UserService {
 
     /* RESET PASSWORD */
     @Transactional
-    public void sendResetPasswordEmail(final Long userId, final LocalDateTime emailVerificationExpiryDate) {
-        final User user = getUserById(userId);
+    public void sendResetPasswordEmail(final UserResetPasswordEmailRequest request, final LocalDateTime emailVerificationExpiryDate) {
+        final User user = getUserByEmail(request.email());
         final VerificationToken savedVerificationToken = verificationTokenService.save(user, emailVerificationExpiryDate);
 
         eventPublisher.publishEvent(EmailVerificationEvent.resetPassword(user.getEmail(), savedVerificationToken.getToken()));

--- a/src/main/java/com/jobnote/domain/user/service/UserService.java
+++ b/src/main/java/com/jobnote/domain/user/service/UserService.java
@@ -3,7 +3,7 @@ package com.jobnote.domain.user.service;
 import com.jobnote.domain.user.domain.User;
 import com.jobnote.domain.verificationtoken.domain.VerificationToken;
 import com.jobnote.domain.user.dto.*;
-import com.jobnote.domain.user.event.SignUpEvent;
+import com.jobnote.domain.user.event.EmailVerificationEvent;
 import com.jobnote.domain.user.repository.UserRepository;
 import com.jobnote.domain.verificationtoken.service.VerificationTokenService;
 import com.jobnote.global.exception.JobNoteException;
@@ -51,7 +51,7 @@ public class UserService {
         final User savedUser = userRepository.save(User.signUp(request.email(), passwordEncoder.encode(request.password()), request.nickname()));
         final VerificationToken savedVerificationToken = verificationTokenService.save(savedUser, emailVerificationExpiryDate);
 
-        eventPublisher.publishEvent(new SignUpEvent(savedUser.getEmail(), savedVerificationToken.getToken()));
+        eventPublisher.publishEvent(new EmailVerificationEvent(savedUser.getEmail(), savedVerificationToken.getToken()));
     }
 
     /* SOCIAL LOGIN SIGN UP */

--- a/src/main/java/com/jobnote/domain/user/service/UserService.java
+++ b/src/main/java/com/jobnote/domain/user/service/UserService.java
@@ -101,6 +101,10 @@ public class UserService {
         eventPublisher.publishEvent(EmailVerificationEvent.resetPassword(user.getEmail(), savedVerificationToken.getToken()));
     }
 
+    public void verifyResetPasswordEmail(final String token, final LocalDateTime currentDate) {
+        verificationTokenService.verifyToken(token, currentDate);
+    }
+
     /* HELPER METHOD */
     private User getByIdOrThrow(final Long id) {
         return userRepository.findById(id)

--- a/src/main/java/com/jobnote/domain/user/service/UserService.java
+++ b/src/main/java/com/jobnote/domain/user/service/UserService.java
@@ -51,7 +51,7 @@ public class UserService {
         final User savedUser = userRepository.save(User.signUp(request.email(), passwordEncoder.encode(request.password()), request.nickname()));
         final VerificationToken savedVerificationToken = verificationTokenService.save(savedUser, emailVerificationExpiryDate);
 
-        eventPublisher.publishEvent(new EmailVerificationEvent(savedUser.getEmail(), savedVerificationToken.getToken()));
+        eventPublisher.publishEvent(EmailVerificationEvent.signUp(savedUser.getEmail(), savedVerificationToken.getToken()));
     }
 
     /* SOCIAL LOGIN SIGN UP */
@@ -95,6 +95,15 @@ public class UserService {
         final User user = getUserById(userId);
         user.updateNickname(request.nickname());
         return UserProfileResponse.from(user);
+    }
+
+    /* RESET PASSWORD */
+    @Transactional
+    public void sendResetPasswordEmail(final Long userId, final LocalDateTime emailVerificationExpiryDate) {
+        final User user = getUserById(userId);
+        final VerificationToken savedVerificationToken = verificationTokenService.save(user, emailVerificationExpiryDate);
+
+        eventPublisher.publishEvent(EmailVerificationEvent.resetPassword(user.getEmail(), savedVerificationToken.getToken()));
     }
 
     /* HELPER METHOD */

--- a/src/main/java/com/jobnote/domain/user/service/UserService.java
+++ b/src/main/java/com/jobnote/domain/user/service/UserService.java
@@ -65,14 +65,9 @@ public class UserService {
     /* EMAIL VERIFICATION */
     @Transactional
     public void verifyEmail(final String token, final LocalDateTime currentDate) {
-        final VerificationToken verificationToken = verificationTokenService.getVerificationTokenByToken(token);
+        final VerificationToken verificationToken = verificationTokenService.verifyToken(token, currentDate);
         final User user = verificationToken.getUser();
-
-        verificationToken.validateExpired(currentDate);
-        verificationToken.validateVerified();
-
         user.accept();
-        verificationToken.complete();
     }
 
     /* GET PROFILE */

--- a/src/main/java/com/jobnote/domain/verificationtoken/domain/VerificationToken.java
+++ b/src/main/java/com/jobnote/domain/verificationtoken/domain/VerificationToken.java
@@ -7,8 +7,7 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 
-import static com.jobnote.global.common.ResponseCode.ALREADY_VERIFIED_TOKEN;
-import static com.jobnote.global.common.ResponseCode.EXPIRED_VERIFICATION_TOKEN;
+import static com.jobnote.global.common.ResponseCode.*;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
@@ -54,12 +53,15 @@ public class VerificationToken {
     }
 
     public void validateVerified() {
-        if (VerificationTokenStatus.VERIFIED.equals(this.status)) {
-            throw new JobNoteException(ALREADY_VERIFIED_TOKEN);
+        if (!VerificationTokenStatus.VERIFIED.equals(this.status)) {
+            throw new JobNoteException(NOT_YET_VERIFIED_TOKEN);
         }
     }
 
-    public void complete() {
+    public void verify() {
+        if (VerificationTokenStatus.VERIFIED.equals(this.status)) {
+            throw new JobNoteException(ALREADY_VERIFIED_TOKEN);
+        }
         this.status = VerificationTokenStatus.VERIFIED;
     }
 }

--- a/src/main/java/com/jobnote/domain/verificationtoken/domain/VerificationToken.java
+++ b/src/main/java/com/jobnote/domain/verificationtoken/domain/VerificationToken.java
@@ -25,7 +25,7 @@ public class VerificationToken {
     @Column(nullable = false, unique = true)
     private String token;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/src/main/java/com/jobnote/domain/verificationtoken/service/VerificationTokenService.java
+++ b/src/main/java/com/jobnote/domain/verificationtoken/service/VerificationTokenService.java
@@ -6,6 +6,7 @@ import com.jobnote.domain.verificationtoken.repository.VerificationTokenReposito
 import com.jobnote.global.exception.JobNoteException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -13,6 +14,7 @@ import java.util.UUID;
 import static com.jobnote.global.common.ResponseCode.NOT_FOUND_VERIFICATION_TOKEN;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class VerificationTokenService {
 
@@ -22,7 +24,19 @@ public class VerificationTokenService {
         return getByTokenOrThrow(token);
     }
 
+    @Transactional
+    public VerificationToken verifyToken(final String token, final LocalDateTime currentDate) {
+        final VerificationToken verificationToken = getVerificationTokenByToken(token);
+
+        verificationToken.validateExpired(currentDate);
+        verificationToken.validateVerified();
+        verificationToken.complete();
+
+        return verificationToken;
+    }
+
     /* CREATE */
+    @Transactional
     public VerificationToken save(final User user, final LocalDateTime emailVerificationExpiryDate) {
         return verificationTokenRepository.save(VerificationToken.create(UUID.randomUUID().toString(), user, emailVerificationExpiryDate));
     }

--- a/src/main/java/com/jobnote/domain/verificationtoken/service/VerificationTokenService.java
+++ b/src/main/java/com/jobnote/domain/verificationtoken/service/VerificationTokenService.java
@@ -29,8 +29,7 @@ public class VerificationTokenService {
         final VerificationToken verificationToken = getVerificationTokenByToken(token);
 
         verificationToken.validateExpired(currentDate);
-        verificationToken.validateVerified();
-        verificationToken.complete();
+        verificationToken.verify();
 
         return verificationToken;
     }

--- a/src/main/java/com/jobnote/global/common/Constants.java
+++ b/src/main/java/com/jobnote/global/common/Constants.java
@@ -1,5 +1,7 @@
 package com.jobnote.global.common;
 
+import java.util.List;
+
 public abstract class Constants {
 
     // uri
@@ -33,6 +35,16 @@ public abstract class Constants {
             "/h2-console/**",
             "/error/**",
     };
+
+    public static final List<String> TOKEN_FILTER_WHITELIST = List.of(
+            "/api/v1/users/signup",
+            "/api/v1/users/verify",
+            "/api/v1/users/reset-password",
+            "/login",
+            "/oauth2",
+            "/h2-console",
+            "/error"
+    );
 
     public static final String[] ONLY_GUEST = {
             "/api/v1/users/signup/social",

--- a/src/main/java/com/jobnote/global/common/Constants.java
+++ b/src/main/java/com/jobnote/global/common/Constants.java
@@ -27,6 +27,7 @@ public abstract class Constants {
     public static final String[] WHITELIST = {
             "/api/v1/users/signup",
             "/api/v1/users/verify",
+            "/api/v1/users/reset-password/**",
             "/login/**",
             "/oauth2/**",
             "/h2-console/**",

--- a/src/main/java/com/jobnote/global/common/ResponseCode.java
+++ b/src/main/java/com/jobnote/global/common/ResponseCode.java
@@ -35,6 +35,7 @@ public enum ResponseCode {
     FORBIDDEN(HttpStatus.FORBIDDEN, "4030", "요청 리소스에 대한 액세스가 금지되었습니다."),
     PENDING_EMAIL_VERIFICATION(HttpStatus.FORBIDDEN, "4031", "이메일 인증이 완료되지 않았습니다."),
     NOT_YET_SIGNED_UP(HttpStatus.FORBIDDEN, "4032", "회원가입 절차가 완료되지 않았습니다."),
+    NOT_YET_VERIFIED_TOKEN(HttpStatus.FORBIDDEN, "4033", "인증이 완료되지 않은 토큰입니다."),
 
     // 404 Not Found
     NOT_FOUND(HttpStatus.NOT_FOUND, "4040", "요청 리소스를 찾을 수 없습니다."),

--- a/src/main/java/com/jobnote/global/config/properties/AppProperties.java
+++ b/src/main/java/com/jobnote/global/config/properties/AppProperties.java
@@ -2,12 +2,15 @@ package com.jobnote.global.config.properties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import java.time.LocalDateTime;
-
 @ConfigurationProperties(prefix = "app")
 public record AppProperties(
         String baseUrl,
-        String emailVerificationPath,
-        LocalDateTime emailVerificationExpiryTime
+        EmailVerificationPathProperties emailVerificationPath
 ) {
+
+    public record EmailVerificationPathProperties(
+            String signUp,
+            String resetPassword
+    ) {
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,4 +39,6 @@ spring:
             user-name-attribute: id
 
 app:
-  email-verification-path: /api/v1/users/verify
+  email-verification-path:
+    sign-up: /api/v1/users/verify
+    reset-password: /api/v1/users/reset-password/verify

--- a/src/test/java/com/jobnote/domain/user/domain/UserTest.java
+++ b/src/test/java/com/jobnote/domain/user/domain/UserTest.java
@@ -81,4 +81,19 @@ class UserTest {
         assertThat(socialUser.getNickname()).isEqualTo(updatedNickname);
     }
 
+    @Test
+    @DisplayName("비밀번호를 재설정한다")
+    void resetPassword() {
+        // given
+        final String existingPassword = "testPassword";
+        final String newPassword = "testNewPassword";
+        final User user = User.signUp("testEmail@test.com", existingPassword, "testNickname");
+
+        // when
+        user.resetPassword(newPassword);
+
+        // then
+        assertThat(user.getPassword()).isEqualTo(newPassword);
+        assertThat(user.getPassword()).isNotEqualTo(existingPassword);
+    }
 }

--- a/src/test/java/com/jobnote/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/jobnote/domain/user/service/UserServiceTest.java
@@ -80,7 +80,7 @@ class UserServiceTest extends ServiceUnitTest {
             then(userRepository).should().existsByNickname(nickname);
             then(userRepository).should().save(any(User.class));
             then(verificationTokenService).should().save(user, emailVerificationExpiryDate);
-            then(applicationEventPublisher).should().publishEvent(new EmailVerificationEvent(email, token));
+            then(applicationEventPublisher).should().publishEvent(EmailVerificationEvent.signUp(email, token));
         }
 
         @Test

--- a/src/test/java/com/jobnote/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/jobnote/domain/user/service/UserServiceTest.java
@@ -8,7 +8,7 @@ import com.jobnote.domain.user.dto.UserAvatarRequest;
 import com.jobnote.domain.user.dto.UserNicknameRequest;
 import com.jobnote.domain.user.dto.UserProfileResponse;
 import com.jobnote.domain.user.dto.UserSignUpRequest;
-import com.jobnote.domain.user.event.SignUpEvent;
+import com.jobnote.domain.user.event.EmailVerificationEvent;
 import com.jobnote.domain.user.repository.UserRepository;
 import com.jobnote.domain.verificationtoken.domain.VerificationTokenStatus;
 import com.jobnote.domain.verificationtoken.service.VerificationTokenService;
@@ -80,7 +80,7 @@ class UserServiceTest extends ServiceUnitTest {
             then(userRepository).should().existsByNickname(nickname);
             then(userRepository).should().save(any(User.class));
             then(verificationTokenService).should().save(user, emailVerificationExpiryDate);
-            then(applicationEventPublisher).should().publishEvent(new SignUpEvent(email, token));
+            then(applicationEventPublisher).should().publishEvent(new EmailVerificationEvent(email, token));
         }
 
         @Test
@@ -98,7 +98,7 @@ class UserServiceTest extends ServiceUnitTest {
             then(userRepository).should().existsByEmail(request.email());
             then(userRepository).should(never()).save(any(User.class));
             then(verificationTokenService).should(never()).save(any(User.class), any(LocalDateTime.class));
-            then(applicationEventPublisher).should(never()).publishEvent(any(SignUpEvent.class));
+            then(applicationEventPublisher).should(never()).publishEvent(any(EmailVerificationEvent.class));
         }
 
         @Test
@@ -116,7 +116,7 @@ class UserServiceTest extends ServiceUnitTest {
             then(userRepository).should().existsByNickname(request.nickname());
             then(userRepository).should(never()).save(any(User.class));
             then(verificationTokenService).should(never()).save(any(User.class), any(LocalDateTime.class));
-            then(applicationEventPublisher).should(never()).publishEvent(any(SignUpEvent.class));
+            then(applicationEventPublisher).should(never()).publishEvent(any(EmailVerificationEvent.class));
         }
     }
 

--- a/src/test/java/com/jobnote/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/jobnote/domain/user/service/UserServiceTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -38,7 +38,7 @@ class UserServiceTest extends ServiceUnitTest {
     private VerificationTokenService verificationTokenService;
 
     @Mock
-    private BCryptPasswordEncoder bCryptPasswordEncoder;
+    private PasswordEncoder passwordEncoder;
 
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
@@ -290,5 +290,27 @@ class UserServiceTest extends ServiceUnitTest {
             then(verificationTokenService).should(never()).save(any(User.class), any(LocalDateTime.class));
             then(applicationEventPublisher).should(never()).publishEvent(any(EmailVerificationEvent.class));
         }
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정")
+    void resetPassword() {
+        // given
+        final String newPassword = "testNewPassword";
+        final String newEncodedPassword = "testNewEncodedPassword";
+        final String token = "testToken";
+        final UserResetPasswordRequest request = new UserResetPasswordRequest(newPassword);
+        final User user = User.signUp("testEmail@test.com", "testPassword", "testNickname");
+        final VerificationToken verificationToken = VerificationToken.create(token, user, LocalDateTime.of(2025, 8, 6, 11, 31));
+        verificationToken.verify();
+
+        given(verificationTokenService.getVerificationTokenByToken(token)).willReturn(verificationToken);
+        given(passwordEncoder.encode(newPassword)).willReturn(newEncodedPassword);
+
+        // when
+        userService.resetPassword(request, token);
+
+        // then
+        assertThat(user.getPassword()).isEqualTo(newEncodedPassword);
     }
 }

--- a/src/test/java/com/jobnote/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/jobnote/domain/user/service/UserServiceTest.java
@@ -3,11 +3,8 @@ package com.jobnote.domain.user.service;
 import com.jobnote.ServiceUnitTest;
 import com.jobnote.domain.user.domain.User;
 import com.jobnote.domain.user.domain.UserRole;
+import com.jobnote.domain.user.dto.*;
 import com.jobnote.domain.verificationtoken.domain.VerificationToken;
-import com.jobnote.domain.user.dto.UserAvatarRequest;
-import com.jobnote.domain.user.dto.UserNicknameRequest;
-import com.jobnote.domain.user.dto.UserProfileResponse;
-import com.jobnote.domain.user.dto.UserSignUpRequest;
 import com.jobnote.domain.user.event.EmailVerificationEvent;
 import com.jobnote.domain.user.repository.UserRepository;
 import com.jobnote.domain.verificationtoken.domain.VerificationTokenStatus;
@@ -26,8 +23,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
-import static com.jobnote.global.common.ResponseCode.DUPLICATED_USER_EMAIL;
-import static com.jobnote.global.common.ResponseCode.DUPLICATED_USER_NICKNAME;
+import static com.jobnote.global.common.ResponseCode.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -250,6 +246,51 @@ class UserServiceTest extends ServiceUnitTest {
             // then
             assertThat(user.getRole()).isEqualTo(UserRole.MEMBER);
             assertThat(verificationToken.getStatus()).isEqualTo(VerificationTokenStatus.VERIFIED);
+        }
+    }
+
+    @Nested
+    @DisplayName("비밀번호 재설정 이메일 전송")
+    class ResetPasswordEmail {
+        @Test
+        @DisplayName("성공")
+        void success() {
+            // given
+            final String email = "testEmail@test.com";
+            final UserResetPasswordEmailRequest request = new UserResetPasswordEmailRequest(email);
+            final User user = User.signUp(email, "testPassword", "testNickname");
+            final String token = "testToken";
+            final LocalDateTime emailVerificationExpiryDate = LocalDateTime.of(2025, 8, 6, 11, 31);
+            final VerificationToken verificationToken = VerificationToken.create(token, user, emailVerificationExpiryDate);
+
+            given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+            given(verificationTokenService.save(user, emailVerificationExpiryDate)).willReturn(verificationToken);
+
+            // when
+            userService.sendResetPasswordEmail(request, emailVerificationExpiryDate);
+
+            // then
+            then(userRepository).should().findByEmail(email);
+            then(verificationTokenService).should().save(user, emailVerificationExpiryDate);
+            then(applicationEventPublisher).should().publishEvent(EmailVerificationEvent.resetPassword(email, token));
+        }
+
+        @Test
+        @DisplayName("실패 - 이메일이 존재하지 않는다.")
+        void fail_DuplicatedEmail() {
+            // given
+            final String email = "testEmail@test.com";
+            final UserResetPasswordEmailRequest request = new UserResetPasswordEmailRequest(email);
+            given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> userService.sendResetPasswordEmail(request, LocalDateTime.now()))
+                    .isInstanceOf(JobNoteException.class)
+                    .hasMessage(NOT_FOUND_USER.getMessage());
+
+            then(userRepository).should().findByEmail(email);
+            then(verificationTokenService).should(never()).save(any(User.class), any(LocalDateTime.class));
+            then(applicationEventPublisher).should(never()).publishEvent(any(EmailVerificationEvent.class));
         }
     }
 }

--- a/src/test/java/com/jobnote/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/jobnote/domain/user/service/UserServiceTest.java
@@ -7,7 +7,6 @@ import com.jobnote.domain.user.dto.*;
 import com.jobnote.domain.verificationtoken.domain.VerificationToken;
 import com.jobnote.domain.user.event.EmailVerificationEvent;
 import com.jobnote.domain.user.repository.UserRepository;
-import com.jobnote.domain.verificationtoken.domain.VerificationTokenStatus;
 import com.jobnote.domain.verificationtoken.service.VerificationTokenService;
 import com.jobnote.global.common.ResponseCode;
 import com.jobnote.global.exception.JobNoteException;
@@ -229,7 +228,7 @@ class UserServiceTest extends ServiceUnitTest {
     @DisplayName("이메일 인증")
     class EmailVerification {
         @Test
-        @DisplayName("성공")
+        @DisplayName("성공 - 회원의 Role은 MEMBER가 된다.")
         void success() {
             // given
             final User user = User.signUp("testEmail@test.com", "testPassword", "testNickname");
@@ -238,14 +237,13 @@ class UserServiceTest extends ServiceUnitTest {
             final String token = UUID.randomUUID().toString();
             final VerificationToken verificationToken = VerificationToken.create(token, user, expiryDate);
 
-            given(verificationTokenService.getVerificationTokenByToken(token)).willReturn(verificationToken);
+            given(verificationTokenService.verifyToken(token, currentDate)).willReturn(verificationToken);
 
             // when
             userService.verifyEmail(token, currentDate);
 
             // then
             assertThat(user.getRole()).isEqualTo(UserRole.MEMBER);
-            assertThat(verificationToken.getStatus()).isEqualTo(VerificationTokenStatus.VERIFIED);
         }
     }
 

--- a/src/test/java/com/jobnote/domain/verificationtoken/domain/VerificationTokenTest.java
+++ b/src/test/java/com/jobnote/domain/verificationtoken/domain/VerificationTokenTest.java
@@ -9,8 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-import static com.jobnote.global.common.ResponseCode.ALREADY_VERIFIED_TOKEN;
-import static com.jobnote.global.common.ResponseCode.EXPIRED_VERIFICATION_TOKEN;
+import static com.jobnote.global.common.ResponseCode.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -67,52 +66,72 @@ class VerificationTokenTest {
     }
 
     @Nested
-    @DisplayName("토큰 기검증 검사")
+    @DisplayName("토큰 검증 완료 여부 검사")
     class ValidateTokenVerified {
         @Test
-        @DisplayName("토큰이 아직 검증되지 않았으면 아무일도 일어나지 않는다.")
-        void notVerified() {
+        @DisplayName("토큰이 검증되었으면 아무일도 일어나지 않는다.")
+        void verified() {
+            // given
+            final User user = User.signUp("testEmail@test.com", "testPassword", "testNickname");
+            final LocalDateTime expiryDate = LocalDateTime.of(2025, 7, 30, 12, 0);
+            final VerificationToken verificationToken = VerificationToken.create(UUID.randomUUID().toString(), user, expiryDate);
+            verificationToken.verify();
+
+            // when
+            verificationToken.validateVerified();
+
+            // then
+            assertThat(verificationToken.getStatus()).isEqualTo(VerificationTokenStatus.VERIFIED);
+        }
+
+        @Test
+        @DisplayName("토큰이 검증되지 않았으면 예외를 발생한다.")
+        void notVerified_ThrowsException() {
+            // given
+            final User user = User.signUp("testEmail@test.com", "testPassword", "testNickname");
+            final LocalDateTime expiryDate = LocalDateTime.of(2025, 7, 30, 12, 0);
+            final VerificationToken verificationToken = VerificationToken.create(UUID.randomUUID().toString(), user, expiryDate);
+
+            // when & then
+            assertThatThrownBy(verificationToken::validateVerified)
+                    .isInstanceOf(JobNoteException.class)
+                    .hasMessage(NOT_YET_VERIFIED_TOKEN.getMessage());
+            assertThat(verificationToken.getStatus()).isEqualTo(VerificationTokenStatus.PENDING);
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 검증")
+    class VerifyToken {
+        @Test
+        @DisplayName("성공 - 토큰의 상태가 VERIFIED로 변경된다.")
+        void success() {
             // given
             final User user = User.signUp("testEmail@test.com", "testPassword", "testNickname");
             final LocalDateTime expiryDate = LocalDateTime.of(2025, 7, 30, 12, 0);
             final VerificationToken verificationToken = VerificationToken.create(UUID.randomUUID().toString(), user, expiryDate);
 
             // when
-            verificationToken.validateVerified();
+            verificationToken.verify();
 
             // then
-            assertThat(verificationToken.getStatus()).isEqualTo(VerificationTokenStatus.PENDING);
+            assertThat(verificationToken.getStatus()).isEqualTo(VerificationTokenStatus.VERIFIED);
         }
 
         @Test
         @DisplayName("토큰이 이미 검증되었으면 예외를 발생한다.")
-        void verified_ThrowsException() {
+        void fail_AlreadyVerified_ThrowsException() {
             // given
             final User user = User.signUp("testEmail@test.com", "testPassword", "testNickname");
             final LocalDateTime expiryDate = LocalDateTime.of(2025, 7, 30, 12, 0);
             final VerificationToken verificationToken = VerificationToken.create(UUID.randomUUID().toString(), user, expiryDate);
-            verificationToken.complete();
+            verificationToken.verify();
 
             // when & then
-            assertThatThrownBy(verificationToken::validateVerified)
+            assertThatThrownBy(verificationToken::verify)
                     .isInstanceOf(JobNoteException.class)
                     .hasMessage(ALREADY_VERIFIED_TOKEN.getMessage());
             assertThat(verificationToken.getStatus()).isEqualTo(VerificationTokenStatus.VERIFIED);
         }
-    }
-
-    @Test
-    @DisplayName("토큰 검증을 완료하면 상태가 VERIFIED로 변경된다.")
-    void completeToken() {
-        // given
-        final User user = User.signUp("testEmail@test.com", "testPassword", "testNickname");
-        final LocalDateTime expiryDate = LocalDateTime.of(2025, 7, 30, 12, 0);
-        final VerificationToken verificationToken = VerificationToken.create(UUID.randomUUID().toString(), user, expiryDate);
-
-        // when
-        verificationToken.complete();
-
-        // then
-        assertThat(verificationToken.getStatus()).isEqualTo(VerificationTokenStatus.VERIFIED);
     }
 }

--- a/src/test/java/com/jobnote/domain/verificationtoken/service/VerificationTokenServiceTest.java
+++ b/src/test/java/com/jobnote/domain/verificationtoken/service/VerificationTokenServiceTest.java
@@ -3,6 +3,7 @@ package com.jobnote.domain.verificationtoken.service;
 import com.jobnote.ServiceUnitTest;
 import com.jobnote.domain.user.domain.User;
 import com.jobnote.domain.verificationtoken.domain.VerificationToken;
+import com.jobnote.domain.verificationtoken.domain.VerificationTokenStatus;
 import com.jobnote.domain.verificationtoken.repository.VerificationTokenRepository;
 import com.jobnote.global.exception.JobNoteException;
 import org.junit.jupiter.api.DisplayName;
@@ -60,6 +61,30 @@ class VerificationTokenServiceTest extends ServiceUnitTest {
             assertThatThrownBy(() -> verificationTokenService.getVerificationTokenByToken(token))
                     .isInstanceOf(JobNoteException.class)
                     .hasMessage(NOT_FOUND_VERIFICATION_TOKEN.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 검증")
+    class VerifyToken {
+        @Test
+        @DisplayName("성공 - 검증 토큰의 상태는 VERIFIED가 된다.")
+        void success() {
+            // given
+            final User user = mock(User.class);
+            final String token = "testToken";
+            final LocalDateTime currentDate = LocalDateTime.of(2025, 7, 29, 12, 0);
+            final LocalDateTime emailVerificationExpiryDate = LocalDateTime.of(2025, 8, 6, 11, 31);
+            final VerificationToken verificationToken = VerificationToken.create(token, user, emailVerificationExpiryDate);
+
+            given(verificationTokenRepository.findByToken(token)).willReturn(Optional.of(verificationToken));
+
+            // when
+            final VerificationToken result = verificationTokenService.verifyToken(token, currentDate);
+
+            // then
+            assertThat(result).isEqualTo(verificationToken);
+            assertThat(result.getStatus()).isEqualTo(VerificationTokenStatus.VERIFIED);
         }
     }
 }


### PR DESCRIPTION
## Resolved Issue
- close #40 

## PR Description
### 이메일 발송 이벤트
- 회원가입과 비밀번호 재설정 모두 '이메일 발송' 이라는 동일한 이벤트를 던지도록 구현했습니다.
  - EmailType enum을 두어 회원가입과 비밀번호 재설정을 구분했습니다.
  - 구체적인 이메일 템플릿은 추후 템플릿 엔진으로 다시 개발할 예정입니다.
```java
public record EmailVerificationEvent(
        String toEmail,
        String token,
        EmailType emailType
) {

    @Getter
    @RequiredArgsConstructor
    public enum EmailType {
        SIGN_UP("회원가입", AppProperties.EmailVerificationPathProperties::signUp),
        RESET_PASSWORD("비밀번호 재설정", AppProperties.EmailVerificationPathProperties::resetPassword),
        ;
```

### 비밀번호 재설정
- 와이어프레임을 기반으로 비밀번호 재설정 API를 다음 세 단계로 구성했습니다.

1. 이메일 발송
  - 회원가입 인증 메일과 동일하게 회원을 구분할 수 있는 토큰을 발급해 메일을 발송합니다.
  - 이메일 템플릿의 인증 링크는 이메일 인증 엔드포인트로 연결됩니다.
2. 이메일 인증
  - 회원가입 메일 인증과 동일하게 토큰의 만료, 기인증 여부 등을 검사하고 인증을 진행합니다.
  - 단순 링크 클릭이기 때문에 회원가입 메일 인증과 동일하게 추후 프론트엔드 URL로 리다이렉트해야 합니다.
3. 비밀번호 재설정
  - 토큰을 쿼리 파라미터로 입력 받아, 업데이트할 회원을 찾습니다.
  - 이메일 인증이 완료된 회원만 비밀번호 재설정할 수 있으므로, 토큰의 상태가 VERIFIED인지 검사합니다.
```java
@PostMapping("/reset-password/email")
public ResponseEntity<ApiResponse<Void>> sendResetPasswordEmail(@RequestBody @Valid final UserResetPasswordEmailRequest request) {
    userService.sendResetPasswordEmail(request, LocalDateTime.now().plusDays(1));
    return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
}

@GetMapping("/reset-password/verify")
public ResponseEntity<ApiResponse<Void>> verifyResetPasswordEmail(@RequestParam("token") final String token) {
    userService.verifyResetPasswordEmail(token, LocalDateTime.now());
    return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
}

@PatchMapping("/reset-password")
public ResponseEntity<ApiResponse<Void>> resetPassword(@RequestBody @Valid final UserResetPasswordRequest request, @RequestParam("token") final String token) {
    userService.resetPassword(request, token);
    return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
}
```

### UserService, VerificationTokenService 책임 분리
- 기존에는 UserService에서 토큰 만료 여부 검사 및 인증 완료를 진행했습니다.
- 하지만 책임이 VerificationTokenService에 있다고 생각해 코드를 분리했습니다.
```java
@Service
public class VerificationTokenService {

  @Transactional
  public VerificationToken verifyToken(final String token, final LocalDateTime currentDate) {
      final VerificationToken verificationToken = getVerificationTokenByToken(token);
  
      verificationToken.validateExpired(currentDate);
      verificationToken.verify();
  
      return verificationToken;
  }
```

### VerificationToken, User 연관관계 매핑
- 예전에 만료되었거나 인증된 토큰은 DB에서 삭제할 계획으로 OneToOne 매핑으로 설정했었습니다.
- 하지만 더 이상 삭제하지 않고, 회원가입과 비밀번호 재설정 등 회원이 여러 개의 토큰을 생성할 수 있으므로 MayToOne 매핑으로 변경했습니다.

## Others