### PR TITLE
fix: 이메일 인증 URL 변경

### DIFF
--- a/src/main/java/com/jobnote/global/common/Constants.java
+++ b/src/main/java/com/jobnote/global/common/Constants.java
@@ -38,8 +38,8 @@ public abstract class Constants {
 
     public static final List<String> TOKEN_FILTER_WHITELIST = List.of(
             "/api/v1/users/signup",
-            "/api/v1/users/verify",
-            "/api/v1/users/reset-password",
+            "/api/v1/verification-emails/signup/verify",
+            "/api/v1/verification-emails/reset-password",
             "/login",
             "/oauth2",
             "/h2-console",

--- a/src/main/java/com/jobnote/global/common/Constants.java
+++ b/src/main/java/com/jobnote/global/common/Constants.java
@@ -28,8 +28,8 @@ public abstract class Constants {
     // whitelist
     public static final String[] WHITELIST = {
             "/api/v1/users/signup",
-            "/api/v1/users/verify",
-            "/api/v1/users/reset-password/**",
+            "/api/v1/verification-emails/signup/verify",
+            "/api/v1/verification-emails/reset-password/**",
             "/login/**",
             "/oauth2/**",
             "/h2-console/**",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,8 +40,8 @@ spring:
 
 app:
   email-verification-path:
-    sign-up: /api/v1/users/verify
-    reset-password: /api/v1/users/reset-password/verify
+    sign-up: /api/v1/verification-emails/signup/verify
+    reset-password: /api/v1/verification-emails/reset-password/verify
 
 file:
   quota:


### PR DESCRIPTION
## Resolved Issue
- close #47

## PR Description
## Issue Description
- VerificationEmailController의 API는 `/api/v1/verification-emails/signup/verify`, `/api/v1/verification-emails/reset-password/verify`이나 아래 application.yml 설정이 이전 UserController에서 쓰이던 주소로 되어있는 문제를 수정하였습니다.


```diff
 app:
   email-verification-path:
-    sign-up: /api/v1/users/verify
+    sign-up: /api/v1/verification-emails/signup/verify
-    reset-password: /api/v1/users/reset-password/verify
+    reset-password: /api/v1/verification-emails/reset-password/verify
```