### PR TITLE
feat: 회원탈퇴 API 개발

### DIFF
--- a/src/main/java/com/jobnote/domain/common/JobNoteTime.java
+++ b/src/main/java/com/jobnote/domain/common/JobNoteTime.java
@@ -1,0 +1,14 @@
+package com.jobnote.domain.common;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+public class JobNoteTime implements Time {
+
+    @Override
+    public LocalDateTime now() {
+        return LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/jobnote/domain/common/Time.java
+++ b/src/main/java/com/jobnote/domain/common/Time.java
@@ -1,0 +1,8 @@
+package com.jobnote.domain.common;
+
+import java.time.LocalDateTime;
+
+public interface Time {
+
+    LocalDateTime now();
+}

--- a/src/main/java/com/jobnote/domain/user/controller/UserController.java
+++ b/src/main/java/com/jobnote/domain/user/controller/UserController.java
@@ -83,7 +83,7 @@ public class UserController {
     }
 
     /* WITHDRAW */
-    @PostMapping("/withdraw")
+    @DeleteMapping("/withdraw")
     public ResponseEntity<ApiResponse<Void>> withdraw(@LoginUser final CustomPrincipal principal) {
         userService.withdraw(principal.getUserId());
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));

--- a/src/main/java/com/jobnote/domain/user/controller/UserController.java
+++ b/src/main/java/com/jobnote/domain/user/controller/UserController.java
@@ -81,4 +81,11 @@ public class UserController {
         userService.resetPassword(request, token);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }
+
+    /* WITHDRAW */
+    @PostMapping("/withdraw")
+    public ResponseEntity<ApiResponse<Void>> withdraw(@LoginUser final CustomPrincipal principal) {
+        userService.withdraw(principal.getUserId());
+        return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
+    }
 }

--- a/src/main/java/com/jobnote/domain/user/domain/User.java
+++ b/src/main/java/com/jobnote/domain/user/domain/User.java
@@ -36,7 +36,7 @@ public class User extends BaseTimeEntity {
     private UserRole role;
 
     @Column(nullable = false)
-    private boolean isDeleted = false;
+    private boolean isDeleted;
 
     private String socialEmail;
 

--- a/src/main/java/com/jobnote/domain/user/domain/User.java
+++ b/src/main/java/com/jobnote/domain/user/domain/User.java
@@ -1,10 +1,13 @@
 package com.jobnote.domain.user.domain;
 
 import com.jobnote.domain.common.BaseTimeEntity;
+import com.jobnote.global.exception.JobNoteException;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+
+import static com.jobnote.global.common.ResponseCode.USER_ALREADY_WITHDRAWN;
 
 @Entity
 @Getter
@@ -89,6 +92,9 @@ public class User extends BaseTimeEntity {
     }
 
     public void withdraw(final LocalDateTime deletedDate) {
+        if (this.isDeleted) {
+            throw new JobNoteException(USER_ALREADY_WITHDRAWN);
+        }
         this.isDeleted = true;
         this.deletedDate = deletedDate;
     }

--- a/src/main/java/com/jobnote/domain/user/domain/User.java
+++ b/src/main/java/com/jobnote/domain/user/domain/User.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Table(name = "users")
-@Builder(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PACKAGE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseTimeEntity {

--- a/src/main/java/com/jobnote/domain/user/domain/User.java
+++ b/src/main/java/com/jobnote/domain/user/domain/User.java
@@ -87,4 +87,9 @@ public class User extends BaseTimeEntity {
     public void resetPassword(final String newPassword) {
         this.password = newPassword;
     }
+
+    public void withdraw(final LocalDateTime deletedDate) {
+        this.isDeleted = true;
+        this.deletedDate = deletedDate;
+    }
 }

--- a/src/main/java/com/jobnote/domain/user/domain/User.java
+++ b/src/main/java/com/jobnote/domain/user/domain/User.java
@@ -4,6 +4,8 @@ import com.jobnote.domain.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Table(name = "users")
@@ -30,12 +32,17 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private UserRole role;
 
+    @Column(nullable = false)
+    private boolean isDeleted = false;
+
     private String socialEmail;
 
     @Enumerated(EnumType.STRING)
     private SocialProvider socialProvider;
 
     private String socialId;
+
+    private LocalDateTime deletedDate;
 
     public static User signUp(final String email, final String password, final String nickname) {
         return User.builder()

--- a/src/main/java/com/jobnote/domain/user/service/UserService.java
+++ b/src/main/java/com/jobnote/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.jobnote.domain.user.service;
 
+import com.jobnote.domain.common.Time;
 import com.jobnote.domain.email.domain.VerificationEmailType;
 import com.jobnote.domain.email.dto.VerificationEmailRequest;
 import com.jobnote.domain.user.domain.User;
@@ -29,6 +30,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final VerificationEmailService verificationEmailService;
+    private final Time time;
 
     public User getUserById(final Long id) {
         return getByIdOrThrow(id);
@@ -104,6 +106,13 @@ public class UserService {
     public void sendVerificationEmail(final VerificationEmailRequest request, final LocalDateTime expiryDate) {
         final User user = getUserByEmail(request.email());
         verificationEmailService.send(user, expiryDate, request.type());
+    }
+
+    /* WITHDRAW */
+    @Transactional
+    public void withdraw(final Long userId) {
+        final User user = this.getUserById(userId);
+        user.withdraw(this.time.now());
     }
 
     /* HELPER METHOD */

--- a/src/main/java/com/jobnote/global/common/ResponseCode.java
+++ b/src/main/java/com/jobnote/global/common/ResponseCode.java
@@ -53,7 +53,8 @@ public enum ResponseCode {
     // 409 Conflict
     CONFLICT(HttpStatus.CONFLICT, "4090", "요청이 서버의 상태와 충돌했습니다."),
     DUPLICATED_USER_NICKNAME(HttpStatus.CONFLICT, "4091", "이미 사용중인 닉네임입니다."),
-    DUPLICATED_USER_EMAIL(HttpStatus.CONFLICT, "4091", "이미 가입된 이메일입니다."),
+    DUPLICATED_USER_EMAIL(HttpStatus.CONFLICT, "4092", "이미 가입된 이메일입니다."),
+    USER_ALREADY_WITHDRAWN(HttpStatus.CONFLICT, "4093", "이미 탈퇴된 회원입니다."),
 
     // 413 Payload Too Large
     UPLOAD_SIZE_LIMIT_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "4130", "총 업로드 허용 용량 100MB을 초과했습니다."),

--- a/src/test/java/com/jobnote/domain/user/domain/UserFixture.java
+++ b/src/test/java/com/jobnote/domain/user/domain/UserFixture.java
@@ -10,4 +10,14 @@ public class UserFixture {
                 .role(UserRole.MEMBER)
                 .build();
     }
+
+    public static User createWithdrawnMember(final String email, final String password, final String nickname) {
+        return User.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .role(UserRole.MEMBER)
+                .isDeleted(true)
+                .build();
+    }
 }

--- a/src/test/java/com/jobnote/domain/user/domain/UserFixture.java
+++ b/src/test/java/com/jobnote/domain/user/domain/UserFixture.java
@@ -1,0 +1,13 @@
+package com.jobnote.domain.user.domain;
+
+public class UserFixture {
+
+    public static User createMember(final String email, final String password, final String nickname) {
+        return User.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .role(UserRole.MEMBER)
+                .build();
+    }
+}

--- a/src/test/java/com/jobnote/domain/user/domain/UserTest.java
+++ b/src/test/java/com/jobnote/domain/user/domain/UserTest.java
@@ -10,7 +10,6 @@ import java.time.LocalDateTime;
 import static com.jobnote.global.common.ResponseCode.USER_ALREADY_WITHDRAWN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 
 class UserTest {
 
@@ -127,9 +126,10 @@ class UserTest {
         void fail_AlreadyWithdrawn_ThrowsException() {
             // given
             final User user = UserFixture.createWithdrawnMember("testEmail@test.com", "testPassword", "testNickname");
+            final LocalDateTime deletedDate = LocalDateTime.of(2025, 8, 11, 21, 30, 0);
 
             // when & then
-            assertThatThrownBy(() -> user.withdraw(any(LocalDateTime.class)))
+            assertThatThrownBy(() -> user.withdraw(deletedDate))
                     .isInstanceOf(JobNoteException.class)
                     .hasMessage(USER_ALREADY_WITHDRAWN.getMessage());
         }

--- a/src/test/java/com/jobnote/domain/user/domain/UserTest.java
+++ b/src/test/java/com/jobnote/domain/user/domain/UserTest.java
@@ -1,11 +1,16 @@
 package com.jobnote.domain.user.domain;
 
+import com.jobnote.global.exception.JobNoteException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
+import static com.jobnote.global.common.ResponseCode.USER_ALREADY_WITHDRAWN;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 
 class UserTest {
 
@@ -99,18 +104,34 @@ class UserTest {
         assertThat(user.getPassword()).isNotEqualTo(existingPassword);
     }
 
-    @Test
-    @DisplayName("회원을 탈퇴한다.")
-    void withdraw() {
-        // given
-        final User user = UserFixture.createMember("testEmail@test.com", "testPassword", "testNickname");
-        final LocalDateTime deletedDate = LocalDateTime.of(2025, 8, 11, 21, 30, 0);
+    @Nested
+    @DisplayName("회원탈퇴")
+    class Withdraw {
+        @Test
+        @DisplayName("성공 - 회원탈퇴하지 않은 회원의 요청은 성공한다.")
+        void success() {
+            // given
+            final User user = UserFixture.createMember("testEmail@test.com", "testPassword", "testNickname");
+            final LocalDateTime deletedDate = LocalDateTime.of(2025, 8, 11, 21, 30, 0);
 
-        // when
-        user.withdraw(deletedDate);
+            // when
+            user.withdraw(deletedDate);
 
-        // then
-        assertThat(user.isDeleted()).isTrue();
-        assertThat(user.getDeletedDate()).isEqualTo(deletedDate);
+            // then
+            assertThat(user.isDeleted()).isTrue();
+            assertThat(user.getDeletedDate()).isEqualTo(deletedDate);
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 탈퇴한 회원의 요청은 예외를 발생한다")
+        void fail_AlreadyWithdrawn_ThrowsException() {
+            // given
+            final User user = UserFixture.createWithdrawnMember("testEmail@test.com", "testPassword", "testNickname");
+
+            // when & then
+            assertThatThrownBy(() -> user.withdraw(any(LocalDateTime.class)))
+                    .isInstanceOf(JobNoteException.class)
+                    .hasMessage(USER_ALREADY_WITHDRAWN.getMessage());
+        }
     }
 }

--- a/src/test/java/com/jobnote/domain/user/domain/UserTest.java
+++ b/src/test/java/com/jobnote/domain/user/domain/UserTest.java
@@ -3,6 +3,8 @@ package com.jobnote.domain.user.domain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class UserTest {
@@ -95,5 +97,20 @@ class UserTest {
         // then
         assertThat(user.getPassword()).isEqualTo(newPassword);
         assertThat(user.getPassword()).isNotEqualTo(existingPassword);
+    }
+
+    @Test
+    @DisplayName("회원을 탈퇴한다.")
+    void withdraw() {
+        // given
+        final User user = UserFixture.createMember("testEmail@test.com", "testPassword", "testNickname");
+        final LocalDateTime deletedDate = LocalDateTime.of(2025, 8, 11, 21, 30, 0);
+
+        // when
+        user.withdraw(deletedDate);
+
+        // then
+        assertThat(user.isDeleted()).isTrue();
+        assertThat(user.getDeletedDate()).isEqualTo(deletedDate);
     }
 }

--- a/src/test/java/com/jobnote/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/jobnote/domain/user/service/UserServiceTest.java
@@ -1,8 +1,10 @@
 package com.jobnote.domain.user.service;
 
 import com.jobnote.ServiceUnitTest;
+import com.jobnote.domain.common.Time;
 import com.jobnote.domain.email.domain.VerificationEmailType;
 import com.jobnote.domain.user.domain.User;
+import com.jobnote.domain.user.domain.UserFixture;
 import com.jobnote.domain.user.domain.UserRole;
 import com.jobnote.domain.user.dto.*;
 import com.jobnote.domain.email.domain.VerificationEmail;
@@ -38,6 +40,9 @@ class UserServiceTest extends ServiceUnitTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private Time time;
 
     @InjectMocks
     private UserService userService;
@@ -258,5 +263,22 @@ class UserServiceTest extends ServiceUnitTest {
 
         // then
         assertThat(user.getPassword()).isEqualTo(newEncodedPassword);
+    }
+
+    @Test
+    @DisplayName("회원탈퇴")
+    void withdraw() {
+        // given
+        final long userId = 1L;
+        final User user = UserFixture.createMember("testEmail@test.com", "testPassword", "testNickname");
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(time.now()).willReturn(LocalDateTime.of(2025, 8, 11, 22, 37, 0));
+
+        // when
+        userService.withdraw(userId);
+
+        // then
+        assertThat(user.isDeleted()).isTrue();
+        assertThat(user.getDeletedDate()).isEqualTo(LocalDateTime.of(2025, 8, 11, 22, 37, 0));
     }
 }

--- a/src/test/java/com/jobnote/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/jobnote/domain/user/service/UserServiceTest.java
@@ -265,20 +265,42 @@ class UserServiceTest extends ServiceUnitTest {
         assertThat(user.getPassword()).isEqualTo(newEncodedPassword);
     }
 
-    @Test
+    @Nested
     @DisplayName("회원탈퇴")
-    void withdraw() {
-        // given
-        final long userId = 1L;
-        final User user = UserFixture.createMember("testEmail@test.com", "testPassword", "testNickname");
-        given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(time.now()).willReturn(LocalDateTime.of(2025, 8, 11, 22, 37, 0));
+    class Withdraw {
+        @Test
+        @DisplayName("성공 - 회원탈퇴하지 않은 회원의 요청은 성공한다.")
+        void success() {
+            // given
+            final long userId = 1L;
+            final User user = UserFixture.createMember("testEmail@test.com", "testPassword", "testNickname");
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(time.now()).willReturn(LocalDateTime.of(2025, 8, 11, 22, 37, 0));
 
-        // when
-        userService.withdraw(userId);
+            // when
+            userService.withdraw(userId);
 
-        // then
-        assertThat(user.isDeleted()).isTrue();
-        assertThat(user.getDeletedDate()).isEqualTo(LocalDateTime.of(2025, 8, 11, 22, 37, 0));
+            // then
+            then(userRepository).should().findById(userId);
+            then(time).should().now();
+            assertThat(user.isDeleted()).isTrue();
+            assertThat(user.getDeletedDate()).isEqualTo(LocalDateTime.of(2025, 8, 11, 22, 37, 0));
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 탈퇴한 회원의 요청은 예외를 발생한다")
+        void fail_AlreadyWithdrawn_ThrowsException() {
+            // given
+            final long userId = 1L;
+            final User user = UserFixture.createWithdrawnMember("testEmail@test.com", "testPassword", "testNickname");
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+            // when & then
+            assertThatThrownBy(() -> userService.withdraw(userId))
+                    .isInstanceOf(JobNoteException.class)
+                    .hasMessage(USER_ALREADY_WITHDRAWN.getMessage());
+            then(userRepository).should().findById(userId);
+            then(time).should().now();
+        }
     }
 }


### PR DESCRIPTION
## Resolved Issue
- close #46 

## PR Description
- 회원탈퇴 API를 개발했습니다.

### User 엔티티 필드 추가
- 탈퇴 여부를 기록하는 `isDeleted` 필드를 추가했습니다. `enum`으로 관리할 필요성을 못느껴 저장 공간과 쿼리 성능을 위해 `boolean`을 사용했습니다.
- 탈퇴 시각을 기록하기 위해 `deletedDate` 필드를 추가했습니다.
 
### `Time` 인터페이스 생성
- 기존에는 하위 계층의 테스트 용이성을 위해 상위 계층인 Controller에서 `LocalDateTime.now()`를 매개변수로 넘겨주도록 구현했었습니다. 그런데 이 방식은 Controller 계층이 아직 테스트하기 어렵다는 문제가 있고, 매개변수를 계속 넘겨줘야 하는 번거로움이 있습니다.
- 이를 해결하기 위해 각 계층에서 인터페이스를 참조해 사용하는 방식으로 변경했습니다.
```java
// before
@Transactional
public void withdraw(final Long userId, final LocalDateTime deletedDate) {
    final User user = this.getUserById(userId);
    user.withdraw(deletedDate);
}

// after
private final Time time;

@Transactional
public void withdraw(final Long userId) {
    final User user = this.getUserById(userId);
    user.withdraw(this.time.now());
}
```

### 테스트 픽스처 메서드 생성
- 기존에는 테스트 코드에서 엔티티 객체를 생성할 때 엔티티 내부의 정적 팩터리 메서드를 그대로 사용했습니다. 그러다 보니 `UserRole`이 고정되는 등 유연성이 떨어졌습니다.
- 이를 해결하기 위해 테스트 픽스처 메서드를 생성했습니다. 이때 `@Builder`를 열어줘야 하는데, `access = AccessLevel.PACKAGE`로 접근 제한을 최소화했습니다.

## Others
- 회원탈퇴와 연관된 다른 로직(문서, 일정 삭제 등)은 추후 추가할 예정입니다.