### PR TITLE
fix: 회원 로직 버그 수정

### DIFF
--- a/src/main/java/com/jobnote/auth/config/SecurityConfig.java
+++ b/src/main/java/com/jobnote/auth/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -18,7 +19,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfigurationSource;
 
 import static com.jobnote.domain.user.domain.UserRole.*;
-import static com.jobnote.domain.user.domain.UserRole.GUEST;
 import static com.jobnote.global.common.Constants.*;
 
 @RequiredArgsConstructor
@@ -64,7 +64,6 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry -> authorizationManagerRequestMatcherRegistry
                         .requestMatchers(WHITELIST).permitAll()
                         .requestMatchers("/api/*/admin/**").hasRole(ADMIN.name())
-                        .requestMatchers(ONLY_GUEST).hasRole(GUEST.name())
                         .anyRequest().hasAnyRole(MEMBER.name(), ADMIN.name()));
 
         http
@@ -80,5 +79,16 @@ public class SecurityConfig {
                         sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return http.build();
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring()
+                .requestMatchers(
+                        "/h2-console/**",
+                        "/swagger-ui/**",
+                        "/v3/api-docs/**",
+                        "/error"
+                );
     }
 }

--- a/src/main/java/com/jobnote/auth/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/jobnote/auth/filter/TokenAuthenticationFilter.java
@@ -61,7 +61,6 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(final HttpServletRequest request) {
-        return TOKEN_FILTER_WHITELIST.stream()
-                .anyMatch(path -> request.getRequestURI().startsWith(path));
+        return TOKEN_FILTER_WHITELIST.contains(request.getRequestURI());
     }
 }

--- a/src/main/java/com/jobnote/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/jobnote/auth/handler/OAuth2LoginSuccessHandler.java
@@ -28,10 +28,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
-        final CustomPrincipal principal = (CustomPrincipal) authentication.getPrincipal();
         final CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
-        final Token token = authTokenService.saveAndGetToken(principal.getUserId());
-        tokenProvider.addTokenToCookie(response, token);
 
         if (UserRole.GUEST.getKey().equals(principal.getRole())) {
             response.sendRedirect(frontendBaseUrl + guestRedirectQueryString(principal.getEmail()));

--- a/src/main/java/com/jobnote/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/jobnote/auth/handler/OAuth2LoginSuccessHandler.java
@@ -28,19 +28,23 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        final CustomPrincipal principal = (CustomPrincipal) authentication.getPrincipal();
         final CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
         final Token token = authTokenService.saveAndGetToken(principal.getUserId());
         tokenProvider.addTokenToCookie(response, token);
 
         if (UserRole.GUEST.getKey().equals(principal.getRole())) {
-            response.sendRedirect(frontendBaseUrl + signUpRequiredQueryParam(true));
+            response.sendRedirect(frontendBaseUrl + guestRedirectQueryString(principal.getEmail()));
             return;
         }
 
-        response.sendRedirect(frontendBaseUrl + signUpRequiredQueryParam(false));
+        final Token token = authTokenService.saveAndGetToken(principal.getUserId());
+        tokenProvider.addTokenToCookie(response, token);
+
+        response.sendRedirect(frontendBaseUrl);
     }
 
-    private String signUpRequiredQueryParam(final boolean result) {
-        return String.format("?sign-up-required=%s", result);
+    private String guestRedirectQueryString(final String email) {
+        return String.format("?sign-up-required=true&email=%s", email);
     }
 }

--- a/src/main/java/com/jobnote/domain/email/controller/VerificationEmailController.java
+++ b/src/main/java/com/jobnote/domain/email/controller/VerificationEmailController.java
@@ -4,10 +4,10 @@ import com.jobnote.domain.email.dto.VerificationEmailRequest;
 import com.jobnote.domain.email.service.VerificationEmailService;
 import com.jobnote.global.common.ApiResponse;
 import com.jobnote.global.common.ResponseCode;
-import com.jobnote.global.util.ResponseUtil;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,6 +20,9 @@ public class VerificationEmailController {
 
     private final VerificationEmailService verificationEmailService;
 
+    @Value("${app.frontend.base-url}")
+    private String frontendBaseUrl;
+
     /* SEND VERIFICATION EMAIL */
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> sendVerificationEmail(@RequestBody @Valid final VerificationEmailRequest request) {
@@ -31,12 +34,12 @@ public class VerificationEmailController {
     @GetMapping("/signup/verify")
     public void verifySignUpEmail(@RequestParam("token") final String token, final HttpServletResponse response) throws IOException {
         verificationEmailService.verifySignUp(token);
-        ResponseUtil.redirectToFrontend(response);
+        response.sendRedirect(frontendBaseUrl);
     }
 
     @GetMapping("/reset-password/verify")
     public void verifyResetPasswordEmail(@RequestParam("token") final String token, final HttpServletResponse response) throws IOException {
         verificationEmailService.verify(token);
-        ResponseUtil.redirectToFrontend(response);
+        response.sendRedirect(frontendBaseUrl);
     }
 }

--- a/src/main/java/com/jobnote/domain/user/controller/UserController.java
+++ b/src/main/java/com/jobnote/domain/user/controller/UserController.java
@@ -40,6 +40,9 @@ public class UserController {
     @PostMapping("/signup/social")
     public ResponseEntity<ApiResponse<Void>> socialSignUp(@RequestBody @Valid final SocialSignUpRequest request, @LoginUser final CustomUserDetails principal) {
         userService.socialSignUp(request, principal.getUserId());
+    public ResponseEntity<ApiResponse<Void>> socialSignUp(@RequestBody @Valid final SocialSignUpRequest request, final HttpServletResponse response) {
+        final Token token = userService.socialSignUp(request);
+        tokenProvider.addTokenToCookie(response, token);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }
 

--- a/src/main/java/com/jobnote/domain/user/controller/UserController.java
+++ b/src/main/java/com/jobnote/domain/user/controller/UserController.java
@@ -38,8 +38,6 @@ public class UserController {
     }
 
     @PostMapping("/signup/social")
-    public ResponseEntity<ApiResponse<Void>> socialSignUp(@RequestBody @Valid final SocialSignUpRequest request, @LoginUser final CustomUserDetails principal) {
-        userService.socialSignUp(request, principal.getUserId());
     public ResponseEntity<ApiResponse<Void>> socialSignUp(@RequestBody @Valid final SocialSignUpRequest request, final HttpServletResponse response) {
         final Token token = userService.socialSignUp(request);
         tokenProvider.addTokenToCookie(response, token);

--- a/src/main/java/com/jobnote/domain/user/dto/SocialSignUpRequest.java
+++ b/src/main/java/com/jobnote/domain/user/dto/SocialSignUpRequest.java
@@ -6,6 +6,9 @@ import lombok.Builder;
 @Builder
 public record SocialSignUpRequest(
 
+        @NotBlank(message = "이메일은 비어있을 수 없습니다.")
+        String email,
+
         @NotBlank(message = "닉네임은 비어있을 수 없습니다.")
         String nickname
 ) {

--- a/src/main/java/com/jobnote/domain/user/service/UserService.java
+++ b/src/main/java/com/jobnote/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.jobnote.domain.user.service;
 
+import com.jobnote.auth.token.Token;
 import com.jobnote.domain.common.Time;
 import com.jobnote.domain.email.domain.VerificationEmailType;
 import com.jobnote.domain.user.domain.User;
@@ -26,6 +27,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final VerificationEmailService verificationEmailService;
+    private final AuthTokenService authTokenService;
     private final UserQueryService userQueryService;
     private final Time time;
 
@@ -44,10 +46,11 @@ public class UserService {
 
     /* SOCIAL LOGIN SIGN UP */
     @Transactional
-    public void socialSignUp(final SocialSignUpRequest request, final Long userId) {
+    public Token socialSignUp(final SocialSignUpRequest request) {
         validateDuplicatedNickname(request.nickname());
-        final User user = userQueryService.getUserById(userId);
+        final User user = userQueryService.getUserByEmail(request.email());
         user.acceptSocial(request.nickname());
+        return authTokenService.saveAndGetToken(user.getId());
     }
 
     /* GET PROFILE */

--- a/src/main/java/com/jobnote/global/common/Constants.java
+++ b/src/main/java/com/jobnote/global/common/Constants.java
@@ -1,6 +1,6 @@
 package com.jobnote.global.common;
 
-import java.util.List;
+import java.util.Set;
 
 public abstract class Constants {
 
@@ -24,7 +24,7 @@ public abstract class Constants {
 
     // whitelist
     public static final String[] WHITELIST = {
-            "/api/v1/users/signup",
+            "/api/v1/users/signup/**",
             "/api/v1/users/login",
             "/api/v1/users/reset-password",
             "/api/v1/verification-emails/**",
@@ -35,19 +35,16 @@ public abstract class Constants {
             "/v3/api-docs/**",
     };
 
-    public static final List<String> TOKEN_FILTER_WHITELIST = List.of(
+    public static final Set<String> TOKEN_FILTER_WHITELIST = Set.of(
             "/api/v1/users/signup",
+            "/api/v1/users/signup/social",
             "/api/v1/users/login",
             "/api/v1/users/reset-password",
             "/api/v1/verification-emails",
-            "/oauth2",
-            "/h2-console",
-            "/error",
-            "/swagger-ui",
-            "/v3/api-docs"
+            "/api/v1/verification-emails/signup/verify",
+            "/api/v1/verification-emails/reset-password/verify",
+            "/oauth2/authorization/naver",
+            "/oauth2/authorization/kakao",
+            "/oauth2/authorization/google"
     );
-
-    public static final String[] ONLY_GUEST = {
-            "/api/v1/users/signup/social",
-    };
 }

--- a/src/main/java/com/jobnote/global/common/Constants.java
+++ b/src/main/java/com/jobnote/global/common/Constants.java
@@ -4,9 +4,6 @@ import java.util.Set;
 
 public abstract class Constants {
 
-    // uri
-    public static final String URI_USER_REISSUE = "/api/v1/users/reissue";
-
     // claim
     public static final String CLAIM_NAME_TOKEN_TYPE = "token";
     public static final String CLAIM_NAME_EMAIL = "email";
@@ -20,7 +17,7 @@ public abstract class Constants {
     public static final String COOKIE_NAME_ACCESS_TOKEN = "access_token";
     public static final String COOKIE_NAME_REFRESH_TOKEN = "refresh_token";
     public static final String COOKIE_PATH_ACCESS_TOKEN = "/";
-    public static final String COOKIE_PATH_REFRESH_TOKEN = URI_USER_REISSUE;
+    public static final String COOKIE_PATH_REFRESH_TOKEN = "/api/v1/users";
 
     // whitelist
     public static final String[] WHITELIST = {

--- a/src/main/java/com/jobnote/global/util/ResponseUtil.java
+++ b/src/main/java/com/jobnote/global/util/ResponseUtil.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jobnote.global.common.ApiResponse;
 import com.jobnote.global.common.ResponseCode;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 
 import java.io.IOException;
@@ -13,17 +12,10 @@ import static com.jobnote.global.common.Constants.CHARACTER_ENCODING;
 
 public class ResponseUtil {
 
-    @Value("${app.frontend.base-url}")
-    private static String frontendBaseUrl;
-
     public static void responseError(final HttpServletResponse response, final ObjectMapper objectMapper, final ResponseCode responseCode) throws IOException {
         response.setStatus(responseCode.getStatus().value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(CHARACTER_ENCODING);
         response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.ofFail(responseCode)));
-    }
-
-    public static void redirectToFrontend(final HttpServletResponse response) throws IOException {
-        response.sendRedirect(frontendBaseUrl);
     }
 }


### PR DESCRIPTION
## Resolved Issue
- close #59

## PR Description
### 소셜 로그인 로직 수정 (https://github.com/Side-Project-JobNote/Backend/commit/f194262b5071358b3db34ff88e2015cbfa0c2662)
- 기존에는 최초 로그인 시 JWT를 발급했었습니다. 하지만 회원가입이 완료된 후에 발급하는 게 안전하다고 판단하여 로직을 수정했습니다.

### 리프레시 토큰 쿠키 path 수정 (https://github.com/Side-Project-JobNote/Backend/commit/6885044cf2d711748010b861ac30762946794d67)
- 기존에는 토큰 재발급 API 에서만 전송되도록 했었습니다. 하지만 로그아웃, 회원탈퇴 등의 API에서도 필요하여 path를 수정했습니다.

### 이메일 인증 리다이렉트 버그 수정 (https://github.com/Side-Project-JobNote/Backend/commit/fcda4701f8671b21d2437e9aba8dcc13c5e2c37a)
- ResponseUtil로 리다이렉트 메서드를 분리했었지만, 스프링 빈의 의존성 주입이 적용되지 않아 원래 방식으로 다시 수정했습니다.

## Others
