### PR TITLE
feat: 지원서-문서 연결 기능 구현

### DIFF
--- a/src/main/java/com/jobnote/domain/applicationform/dto/ApplicationFormRequest.java
+++ b/src/main/java/com/jobnote/domain/applicationform/dto/ApplicationFormRequest.java
@@ -2,6 +2,7 @@ package com.jobnote.domain.applicationform.dto;
 
 import com.jobnote.domain.applicationform.domain.ApplicationForm;
 import com.jobnote.domain.applicationform.domain.ApplicationFormStatus;
+import com.jobnote.domain.applicationformdocument.dto.ApplicationFormDocumentRequest;
 import com.jobnote.domain.schedule.dto.ScheduleRequest;
 import com.jobnote.domain.user.domain.User;
 import jakarta.validation.Valid;
@@ -9,7 +10,6 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-import java.util.Collections;
 import java.util.List;
 
 public record ApplicationFormRequest(
@@ -35,7 +35,10 @@ public record ApplicationFormRequest(
         ApplicationFormStatus status,
 
         @Valid
-        List<ScheduleRequest> schedules
+        List<ScheduleRequest> schedules,
+
+        @Valid
+        List<ApplicationFormDocumentRequest> documents
 ) {
     public ApplicationForm toEntity(final User user) {
         return ApplicationForm.builder()
@@ -52,8 +55,14 @@ public record ApplicationFormRequest(
                 .build();
     }
 
+    /* null-safe */
     @Override
     public List<ScheduleRequest> schedules() {
-        return schedules != null ? schedules : Collections.emptyList();
+        return schedules != null ? schedules : List.of();
+    }
+
+    @Override
+    public List<ApplicationFormDocumentRequest> documents() {
+        return documents != null ? documents : List.of();
     }
 }

--- a/src/main/java/com/jobnote/domain/applicationform/dto/ApplicationFormResponse.java
+++ b/src/main/java/com/jobnote/domain/applicationform/dto/ApplicationFormResponse.java
@@ -2,11 +2,11 @@ package com.jobnote.domain.applicationform.dto;
 
 import com.jobnote.domain.applicationform.domain.ApplicationForm;
 import com.jobnote.domain.applicationform.domain.ApplicationFormStatus;
+import com.jobnote.domain.document.dto.DocumentSimpleResponse;
 import com.jobnote.domain.schedule.dto.ScheduleResponse;
 import lombok.AccessLevel;
 import lombok.Builder;
 
-import java.util.Collections;
 import java.util.List;
 
 @Builder(access = AccessLevel.PRIVATE)
@@ -21,9 +21,10 @@ public record ApplicationFormResponse(
         String position,
         String memo,
         ApplicationFormStatus status,
-        List<ScheduleResponse> schedules
+        List<ScheduleResponse> schedules,
+        List<DocumentSimpleResponse> documents
 ) {
-    public static ApplicationFormResponse from(final ApplicationForm form, final List<ScheduleResponse> schedules) {
+    public static ApplicationFormResponse from(final ApplicationForm form, final List<ScheduleResponse> schedules, final List<DocumentSimpleResponse> documents) {
         return ApplicationFormResponse.builder()
                 .id(form.getId())
                 .companyName(form.getCompanyName())
@@ -36,11 +37,18 @@ public record ApplicationFormResponse(
                 .memo(form.getMemo())
                 .status(form.getStatus())
                 .schedules(schedules)
+                .documents(documents)
                 .build();
     }
 
+    /* null-safe */
     @Override
     public List<ScheduleResponse> schedules() {
-        return schedules != null ? schedules : Collections.emptyList();
+        return schedules != null ? schedules : List.of();
+    }
+
+    @Override
+    public List<DocumentSimpleResponse> documents() {
+        return documents != null ? documents : List.of();
     }
 }

--- a/src/main/java/com/jobnote/domain/applicationform/dto/ApplicationFormSimpleResponse.java
+++ b/src/main/java/com/jobnote/domain/applicationform/dto/ApplicationFormSimpleResponse.java
@@ -1,0 +1,23 @@
+package com.jobnote.domain.applicationform.dto;
+
+import com.jobnote.domain.applicationform.domain.ApplicationForm;
+import com.jobnote.domain.applicationform.domain.ApplicationFormStatus;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ApplicationFormSimpleResponse(
+        Long id,
+        String companyName,
+        String companyAddress,
+        ApplicationFormStatus status
+) {
+    public static ApplicationFormSimpleResponse from(final ApplicationForm applicationForm) {
+        return ApplicationFormSimpleResponse.builder()
+                .id(applicationForm.getId())
+                .companyName(applicationForm.getCompanyName())
+                .companyAddress(applicationForm.getCompanyAddress())
+                .status(applicationForm.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/jobnote/domain/applicationform/service/ApplicationFormService.java
+++ b/src/main/java/com/jobnote/domain/applicationform/service/ApplicationFormService.java
@@ -1,9 +1,14 @@
 package com.jobnote.domain.applicationform.service;
 
 import com.jobnote.domain.applicationform.domain.ApplicationForm;
+import com.jobnote.domain.applicationform.dto.ApplicationFormSimpleResponse;
+import com.jobnote.domain.applicationformdocument.domain.ApplicationFormDocument;
+import com.jobnote.domain.applicationformdocument.dto.ApplicationFormDocumentRequest;
 import com.jobnote.domain.applicationform.repository.ApplicationFormRepository;
 import com.jobnote.domain.applicationform.dto.ApplicationFormRequest;
 import com.jobnote.domain.applicationform.dto.ApplicationFormResponse;
+import com.jobnote.domain.applicationformdocument.service.ApplicationFormDocumentService;
+import com.jobnote.domain.document.dto.DocumentSimpleResponse;
 import com.jobnote.domain.schedule.dto.ScheduleResponse;
 import com.jobnote.domain.schedule.service.ScheduleService;
 import com.jobnote.global.exception.JobNoteException;
@@ -15,6 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.jobnote.global.common.ResponseCode.NOT_FOUND_APPLICATION_FORM;
 
@@ -26,6 +34,7 @@ public class ApplicationFormService {
     private final ApplicationFormRepository applicationFormRepository;
     private final UserService userService;
     private final ScheduleService scheduleService;
+    private final ApplicationFormDocumentService applicationFormDocumentService;
 
     /* READ */
     public ApplicationFormResponse getById(final Long userId, final Long formId) {
@@ -33,8 +42,9 @@ public class ApplicationFormService {
         form.validateOwner(userId);
 
         List<ScheduleResponse> schedules = scheduleService.getAllByApplicationFormId(userId, formId);
+        List<DocumentSimpleResponse> documents = applicationFormDocumentService.getSimpleResponsesByApplicationFormId(userId, formId);
 
-        return ApplicationFormResponse.from(form, schedules);
+        return ApplicationFormResponse.from(form, schedules, documents);
     }
 
     public List<ApplicationFormResponse> getAll(final Long userId) {
@@ -42,9 +52,22 @@ public class ApplicationFormService {
         List<Long> formIds = forms.stream().map(ApplicationForm::getId).toList();
 
         Map<Long, List<ScheduleResponse>> schedulesByFormId = scheduleService.getAllGroupedByApplicationFormIds(userId, formIds);
+        Map<Long, List<DocumentSimpleResponse>> documentsByFormId = applicationFormDocumentService.getSimpleResponsesGroupedByApplicationFormIds(userId, formIds);
 
         return forms.stream()
-                .map(form -> ApplicationFormResponse.from(form, schedulesByFormId.getOrDefault(form.getId(), List.of())))
+                .map(form -> ApplicationFormResponse.from(
+                        form,
+                        schedulesByFormId.getOrDefault(form.getId(), List.of()),
+                        documentsByFormId.getOrDefault(form.getId(), List.of()))
+                )
+                .toList();
+    }
+
+    public List<ApplicationFormSimpleResponse> getAllSimple(final Long userId) {
+        List<ApplicationForm> forms = applicationFormRepository.findAllByUserId(userId);
+
+        return forms.stream()
+                .map(ApplicationFormSimpleResponse::from)
                 .toList();
     }
 
@@ -53,8 +76,14 @@ public class ApplicationFormService {
     public Long save(final Long userId, final ApplicationFormRequest request) {
         User user = userService.getUserById(userId);
 
+        // 지원서 생성
         ApplicationForm form = applicationFormRepository.save(request.toEntity(user));
+
+        // 일정 등록
         scheduleService.saveAll(userId, form, request.schedules());
+
+        // 연결된 문서 등록
+        applicationFormDocumentService.saveAll(form, request.documents());
 
         return form.getId();
     }
@@ -65,8 +94,14 @@ public class ApplicationFormService {
         ApplicationForm form = getByIdOrThrow(formId);
         form.validateOwner(userId);
 
+        // 지원서 업데이트
         form.update(request);
+
+        // 일정 업데이트
         scheduleService.updateAll(userId, form, request.schedules());
+
+        // 연결된 문서 업데이트
+        updateApplicationFormDocuments(userId, form, request.documents());
     }
 
     /* DELETE */
@@ -76,6 +111,7 @@ public class ApplicationFormService {
         form.validateOwner(userId);
 
         scheduleService.deleteAllByApplicationFormId(form.getId());
+        applicationFormDocumentService.deleteAllByApplicationFormId(form.getId());
         applicationFormRepository.delete(form);
     }
 
@@ -83,5 +119,30 @@ public class ApplicationFormService {
     public ApplicationForm getByIdOrThrow(final Long formId) {
         return applicationFormRepository.findById(formId)
                 .orElseThrow(() -> new JobNoteException(NOT_FOUND_APPLICATION_FORM));
+    }
+
+    private void updateApplicationFormDocuments(final Long userId, final ApplicationForm form, final List<ApplicationFormDocumentRequest> requests) {
+        // 기존 연결된 문서 조회
+        List<ApplicationFormDocument> existsDocuments = applicationFormDocumentService.getAllByApplicationFormId(userId, form.getId());
+
+        // 요청 문서 ID 목록
+        Set<Long> requestsIds = requests.stream()
+                .map(ApplicationFormDocumentRequest::id)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        // 삭제 : 기존 문서 중 요청에 없는 문서 삭제
+        for (ApplicationFormDocument document : existsDocuments) {
+            if (!requestsIds.contains(document.getId())) {
+                applicationFormDocumentService.delete(document);
+            }
+        }
+
+        // 신규 생성 (
+        for (ApplicationFormDocumentRequest req : requests) {
+            if (req.id() == null) {
+                applicationFormDocumentService.saveAll(form, List.of(req));
+            }
+        }
     }
 }

--- a/src/main/java/com/jobnote/domain/applicationformdocument/domain/ApplicationFormDocument.java
+++ b/src/main/java/com/jobnote/domain/applicationformdocument/domain/ApplicationFormDocument.java
@@ -1,0 +1,49 @@
+package com.jobnote.domain.applicationformdocument.domain;
+
+import com.jobnote.domain.applicationform.domain.ApplicationForm;
+import com.jobnote.domain.common.BaseTimeEntity;
+import com.jobnote.domain.document.domain.Document;
+import com.jobnote.global.exception.JobNoteException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static com.jobnote.global.common.ResponseCode.FORBIDDEN;
+
+@Entity
+@Getter
+@Table(name = "application_form_document")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApplicationFormDocument extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "application_form_document_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "application_form_id")
+    private ApplicationForm applicationForm;
+
+    @ManyToOne
+    @JoinColumn(name = "document_id")
+    private Document document;
+
+    @Builder
+    public ApplicationFormDocument(
+            final ApplicationForm applicationForm,
+            final Document document
+    ) {
+        this.applicationForm = applicationForm;
+        this.document = document;
+    }
+
+    public void validateOwner(final Long userId) {
+        if (!this.applicationForm.getUser().getId().equals(userId) &&
+                !this.document.getUser().getId().equals(userId)) {
+            throw new JobNoteException(FORBIDDEN);
+        }
+    }
+}

--- a/src/main/java/com/jobnote/domain/applicationformdocument/dto/ApplicationFormDocumentRequest.java
+++ b/src/main/java/com/jobnote/domain/applicationformdocument/dto/ApplicationFormDocumentRequest.java
@@ -1,0 +1,20 @@
+package com.jobnote.domain.applicationformdocument.dto;
+
+import com.jobnote.domain.applicationform.domain.ApplicationForm;
+import com.jobnote.domain.applicationformdocument.domain.ApplicationFormDocument;
+import com.jobnote.domain.document.domain.Document;
+import jakarta.validation.constraints.NotNull;
+
+public record ApplicationFormDocumentRequest(
+        Long id,
+
+        @NotNull(message = "문서 ID는 null일 수 없습니다.")
+        Long documentId
+) {
+    public ApplicationFormDocument toEntity(final ApplicationForm form, final Document document) {
+        return ApplicationFormDocument.builder()
+                .applicationForm(form)
+                .document(document)
+                .build();
+    }
+}

--- a/src/main/java/com/jobnote/domain/applicationformdocument/repository/ApplicationFormDocumentRepository.java
+++ b/src/main/java/com/jobnote/domain/applicationformdocument/repository/ApplicationFormDocumentRepository.java
@@ -1,0 +1,16 @@
+package com.jobnote.domain.applicationformdocument.repository;
+
+import com.jobnote.domain.applicationformdocument.domain.ApplicationFormDocument;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface ApplicationFormDocumentRepository extends JpaRepository<ApplicationFormDocument, Long> {
+    // 해당 지원서에 속한 문서(지원서-문서 맵핑 엔티티) 목록 반환
+    @Query("select afd from ApplicationFormDocument afd join fetch afd.applicationForm af join fetch af.user where af.user.id = :userId and af.id in :formId")
+    List<ApplicationFormDocument> findAllByUserIdAndApplicationFormIdIn(final Long userId, final List<Long> formId);
+
+    // 해당 지원서에 속한 문서 연결 해제
+    void deleteAllByApplicationFormId(final Long formId);
+}

--- a/src/main/java/com/jobnote/domain/applicationformdocument/repository/ApplicationFormDocumentRepository.java
+++ b/src/main/java/com/jobnote/domain/applicationformdocument/repository/ApplicationFormDocumentRepository.java
@@ -13,4 +13,7 @@ public interface ApplicationFormDocumentRepository extends JpaRepository<Applica
 
     // 해당 지원서에 속한 문서 연결 해제
     void deleteAllByApplicationFormId(final Long formId);
+
+    // 해당 문서에 속한 지원서 연결 해제
+    void deleteAllByDocumentId(final Long documentId);
 }

--- a/src/main/java/com/jobnote/domain/applicationformdocument/service/ApplicationFormDocumentService.java
+++ b/src/main/java/com/jobnote/domain/applicationformdocument/service/ApplicationFormDocumentService.java
@@ -1,0 +1,81 @@
+package com.jobnote.domain.applicationformdocument.service;
+
+import com.jobnote.domain.applicationform.domain.ApplicationForm;
+import com.jobnote.domain.applicationformdocument.domain.ApplicationFormDocument;
+import com.jobnote.domain.applicationformdocument.dto.ApplicationFormDocumentRequest;
+import com.jobnote.domain.applicationformdocument.repository.ApplicationFormDocumentRepository;
+import com.jobnote.domain.document.domain.Document;
+import com.jobnote.domain.document.dto.DocumentSimpleResponse;
+import com.jobnote.domain.document.repository.DocumentRepository;
+import com.jobnote.global.exception.JobNoteException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.jobnote.global.common.ResponseCode.NOT_FOUND_DOCUMENT;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ApplicationFormDocumentService {
+
+    private final ApplicationFormDocumentRepository applicationFormDocumentRepository;
+    private final DocumentRepository documentRepository;
+
+    /* READ */
+    public List<ApplicationFormDocument> getAllByApplicationFormId(final Long userId, final Long formId) {
+        return applicationFormDocumentRepository.findAllByUserIdAndApplicationFormIdIn(userId, List.of(formId));
+    }
+
+    public List<DocumentSimpleResponse> getSimpleResponsesByApplicationFormId(final Long userId, final Long formId) {
+        return applicationFormDocumentRepository.findAllByUserIdAndApplicationFormIdIn(userId, List.of(formId)).stream()
+                .map(afd -> DocumentSimpleResponse.from(afd.getDocument()))
+                .toList();
+    }
+
+    public Map<Long, List<DocumentSimpleResponse>> getSimpleResponsesGroupedByApplicationFormIds(final Long userId, final List<Long> formIds) {
+        List<ApplicationFormDocument> list = applicationFormDocumentRepository.findAllByUserIdAndApplicationFormIdIn(userId, formIds);
+
+        return list.stream()
+                .collect(Collectors.groupingBy(
+                        // 각 문서가 속한 지원서의 ID를 기준으로 그룹핑
+                        document -> document.getApplicationForm().getId(),
+                        // 그룹핑된 문서들을 DocumentSimpleResponse로 변환하여 List로 수집
+                        Collectors.mapping(
+                                afd -> DocumentSimpleResponse.from(afd.getDocument()),
+                                Collectors.toList()
+                        )
+                ));
+    }
+
+    /* CREATE */
+    @Transactional
+    public void saveAll(final ApplicationForm form, final List<ApplicationFormDocumentRequest> requests) {
+        for (ApplicationFormDocumentRequest request : requests) {
+            Document document = getByIdOrThrow(request.documentId());
+            ApplicationFormDocument entity = request.toEntity(form, document);
+            applicationFormDocumentRepository.save(entity);
+        }
+    }
+
+    /* DELETE */
+    @Transactional
+    public void deleteAllByApplicationFormId(final Long formId) {
+        applicationFormDocumentRepository.deleteAllByApplicationFormId(formId);
+    }
+
+    @Transactional
+    public void delete(final ApplicationFormDocument document) {
+        applicationFormDocumentRepository.delete(document);
+    }
+
+    /* HELPER METHOD */
+    private Document getByIdOrThrow(final Long docId) {
+        return documentRepository.findById(docId)
+                .orElseThrow(() -> new JobNoteException(NOT_FOUND_DOCUMENT));
+    }
+}

--- a/src/main/java/com/jobnote/domain/applicationformdocument/service/ApplicationFormDocumentService.java
+++ b/src/main/java/com/jobnote/domain/applicationformdocument/service/ApplicationFormDocumentService.java
@@ -69,6 +69,11 @@ public class ApplicationFormDocumentService {
     }
 
     @Transactional
+    public void deleteAllByDocumentId(final Long documentId) {
+        applicationFormDocumentRepository.deleteAllByDocumentId(documentId);
+    }
+
+    @Transactional
     public void delete(final ApplicationFormDocument document) {
         applicationFormDocumentRepository.delete(document);
     }

--- a/src/main/java/com/jobnote/domain/document/controller/DocumentController.java
+++ b/src/main/java/com/jobnote/domain/document/controller/DocumentController.java
@@ -82,7 +82,7 @@ public class DocumentController implements DocumentApi {
             @PathVariable final Long documentId,
             @LoginUser final CustomUserDetails principal
     ) {
-        documentService.deleteDocument(principal.getUserId(), documentId);
+        documentService.delete(principal.getUserId(), documentId);
 
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }

--- a/src/main/java/com/jobnote/domain/document/domain/Document.java
+++ b/src/main/java/com/jobnote/domain/document/domain/Document.java
@@ -1,6 +1,5 @@
 package com.jobnote.domain.document.domain;
 
-import com.jobnote.domain.applicationform.domain.ApplicationForm;
 import com.jobnote.domain.common.BaseTimeEntity;
 import com.jobnote.domain.user.domain.User;
 import com.jobnote.global.exception.JobNoteException;
@@ -27,10 +26,6 @@ public class Document extends BaseTimeEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "application_form_id")
-    private ApplicationForm applicationForm;
-
     @Enumerated(EnumType.STRING)
     private DocumentType type;
 
@@ -39,12 +34,10 @@ public class Document extends BaseTimeEntity {
     @Builder
     public Document(
             final User user,
-            final ApplicationForm applicationForm,
             final DocumentType documentType,
             final String title
     ) {
         this.user = user;
-        this.applicationForm = applicationForm;
         this.type = documentType;
         this.title = title;
     }

--- a/src/main/java/com/jobnote/domain/document/dto/DocumentResponse.java
+++ b/src/main/java/com/jobnote/domain/document/dto/DocumentResponse.java
@@ -1,26 +1,29 @@
 package com.jobnote.domain.document.dto;
 
+import com.jobnote.domain.applicationform.dto.ApplicationFormSimpleResponse;
 import com.jobnote.domain.document.domain.Document;
 import com.jobnote.domain.document.domain.DocumentType;
 import lombok.AccessLevel;
 import lombok.Builder;
 
 import java.time.LocalDate;
-
+import java.util.List;
 
 @Builder(access = AccessLevel.PRIVATE)
 public record DocumentResponse(
         Long id,
         DocumentType type,
         String title,
-        LocalDate lastModifiedDate
+        LocalDate lastModifiedDate,
+        List<ApplicationFormSimpleResponse> applicationForms
 ) {
-    public static DocumentResponse from(final Document document) {
+    public static DocumentResponse from(final Document document, final List<ApplicationFormSimpleResponse> applicationForms) {
         return DocumentResponse.builder()
                 .id(document.getId())
                 .type(document.getType())
                 .title(document.getTitle())
                 .lastModifiedDate(document.getModifiedDate().toLocalDate())
+                .applicationForms(applicationForms)
                 .build();
     }
 }

--- a/src/main/java/com/jobnote/domain/document/dto/DocumentSimpleResponse.java
+++ b/src/main/java/com/jobnote/domain/document/dto/DocumentSimpleResponse.java
@@ -1,0 +1,21 @@
+package com.jobnote.domain.document.dto;
+
+import com.jobnote.domain.document.domain.Document;
+import com.jobnote.domain.document.domain.DocumentType;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record DocumentSimpleResponse(
+        Long id,
+        DocumentType type,
+        String title
+) {
+    public static DocumentSimpleResponse from(final Document document) {
+        return DocumentSimpleResponse.builder()
+                .id(document.getId())
+                .type(document.getType())
+                .title(document.getTitle())
+                .build();
+    }
+}

--- a/src/main/java/com/jobnote/domain/document/repository/DocumentRepository.java
+++ b/src/main/java/com/jobnote/domain/document/repository/DocumentRepository.java
@@ -2,14 +2,9 @@ package com.jobnote.domain.document.repository;
 
 import com.jobnote.domain.document.domain.Document;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface DocumentRepository extends JpaRepository<Document, Long> {
-    /* 해당 지원서의 문서 목록 조회 */
-    @Query("select d from Document d join fetch d.applicationForm af join fetch af.user where af.user.id = :userId and af.id = :formId")
-    List<Document> findAllByUserIdAndApplicationFormId(final Long userId, final Long formId);
-
     List<Document> findAllByUserId(final Long userId);
 }

--- a/src/main/java/com/jobnote/domain/document/service/DocumentService.java
+++ b/src/main/java/com/jobnote/domain/document/service/DocumentService.java
@@ -1,5 +1,6 @@
 package com.jobnote.domain.document.service;
 
+import com.jobnote.domain.applicationform.service.ApplicationFormService;
 import com.jobnote.domain.document.domain.Document;
 import com.jobnote.domain.document.domain.DocumentVersion;
 import com.jobnote.domain.document.dto.DocumentRequest;
@@ -28,6 +29,7 @@ public class DocumentService {
     private final DocumentVersionRepository documentVersionRepository;
     private final UserService userService;
     private final S3Service s3Service;
+    private final ApplicationFormService applicationFormService;
 
     @Transactional
     public Long uploadNewDocument(final Long userId, final DocumentRequest request) {
@@ -50,7 +52,7 @@ public class DocumentService {
 
     public List<DocumentResponse> getAll(final Long userId) {
         return documentRepository.findAllByUserId(userId).stream()
-                .map(DocumentResponse::from).toList();
+                .map(document -> DocumentResponse.from(document, applicationFormService.getAllSimple(userId))).toList();
     }
 
     public List<DocumentVersionResponse> getAllVersions(final Long userId, final Long documentId) {

--- a/src/main/java/com/jobnote/domain/document/service/DocumentService.java
+++ b/src/main/java/com/jobnote/domain/document/service/DocumentService.java
@@ -1,6 +1,7 @@
 package com.jobnote.domain.document.service;
 
 import com.jobnote.domain.applicationform.service.ApplicationFormService;
+import com.jobnote.domain.applicationformdocument.service.ApplicationFormDocumentService;
 import com.jobnote.domain.document.domain.Document;
 import com.jobnote.domain.document.domain.DocumentVersion;
 import com.jobnote.domain.document.dto.DocumentRequest;
@@ -30,6 +31,7 @@ public class DocumentService {
     private final UserService userService;
     private final S3Service s3Service;
     private final ApplicationFormService applicationFormService;
+    private final ApplicationFormDocumentService applicationFormDocumentService;
 
     @Transactional
     public Long uploadNewDocument(final Long userId, final DocumentRequest request) {
@@ -63,7 +65,7 @@ public class DocumentService {
     }
 
     @Transactional
-    public void deleteDocument(final Long userId, final Long documentId) {
+    public void delete(final Long userId, final Long documentId) {
         Document document = getByIdOrThrow(documentId);
         document.validateOwner(userId);
 
@@ -75,6 +77,7 @@ public class DocumentService {
 
         // 엔티티 삭제
         documentVersionRepository.deleteAllByDocumentId(documentId);
+        applicationFormDocumentService.deleteAllByDocumentId(documentId);
         documentRepository.delete(document);
     }
 
@@ -82,7 +85,7 @@ public class DocumentService {
     public void deleteAllDocuments(final Long userId) {
         List<Document> documents = documentRepository.findAllByUserId(userId);
         for (Document document : documents) {
-            deleteDocument(userId, document.getId());
+            delete(userId, document.getId());
         }
     }
 

--- a/src/main/java/com/jobnote/domain/schedule/domain/Schedule.java
+++ b/src/main/java/com/jobnote/domain/schedule/domain/Schedule.java
@@ -40,7 +40,7 @@ public class Schedule extends BaseTimeEntity {
 
     @Builder
     public Schedule(
-            final ApplicationForm  applicationForm,
+            final ApplicationForm applicationForm,
             final String title,
             final String memo,
             final LocalDateTime dateTime,

--- a/src/main/java/com/jobnote/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/jobnote/domain/schedule/repository/ScheduleRepository.java
@@ -3,7 +3,6 @@ package com.jobnote.domain.schedule.repository;
 import com.jobnote.domain.schedule.domain.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,14 +12,10 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @Query("select s from Schedule s join fetch s.applicationForm af join fetch af.user where af.user.id = :userId and s.dateTime between :startDate and :endDate")
     List<Schedule> findAllByUserIdAndDateTimeBetween(final Long userId, final LocalDateTime startDate, final LocalDateTime endDate);
 
-    /* 해당 지원서의 일정 목록 조회 */
-    @Query("select s from Schedule s join fetch s.applicationForm af join fetch af.user where af.user.id = :userId and af.id = :formId")
-    List<Schedule> findAllByUserIdAndApplicationFormId(final Long userId, final Long formId);
-
     /* 여러 지원서의 일정 목록 전체 조회 */
     @Query("select s from Schedule s join fetch s.applicationForm af join fetch af.user where af.user.id = :userId and af.id in :formIds")
-    List<Schedule> findAllByUserIdAndApplicationFormIds(@Param("userId") Long userId, @Param("formIds") List<Long> formIds);
+    List<Schedule> findAllByUserIdAndApplicationFormIdIn(final Long userId, final List<Long> formIds);
 
     /* 해당 지원서의 일정 목록 삭제 */
-    void deleteAllByApplicationFormId(Long formId);
+    void deleteAllByApplicationFormId(final Long formId);
 }

--- a/src/main/java/com/jobnote/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/jobnote/domain/schedule/service/ScheduleService.java
@@ -42,13 +42,13 @@ public class ScheduleService {
     }
 
     public List<ScheduleResponse> getAllByApplicationFormId(final Long userId, final Long formId) {
-        return scheduleRepository.findAllByUserIdAndApplicationFormId(userId, formId).stream()
+        return scheduleRepository.findAllByUserIdAndApplicationFormIdIn(userId, List.of(formId)).stream()
                 .map(ScheduleResponse::from)
                 .toList();
     }
 
     public Map<Long, List<ScheduleResponse>> getAllGroupedByApplicationFormIds(final Long userId, final List<Long> formIds) {
-        List<Schedule> schedules = scheduleRepository.findAllByUserIdAndApplicationFormIds(userId, formIds);
+        List<Schedule> schedules = scheduleRepository.findAllByUserIdAndApplicationFormIdIn(userId, formIds);
 
         return schedules.stream()
                 .collect(Collectors.groupingBy(
@@ -92,7 +92,7 @@ public class ScheduleService {
     @Transactional
     public void updateAll(final Long userId, final ApplicationForm form, final List<ScheduleRequest> requests) {
         // 기존 일정 조회
-        List<Schedule> existsSchedules = scheduleRepository.findAllByUserIdAndApplicationFormId(userId, form.getId());
+        List<Schedule> existsSchedules = scheduleRepository.findAllByUserIdAndApplicationFormIdIn(userId, List.of(form.getId()));
 
         // 요청 일정 ID 목록
         Set<Long> requestsIds = requests.stream()

--- a/src/main/java/com/jobnote/global/config/CorsConfig.java
+++ b/src/main/java/com/jobnote/global/config/CorsConfig.java
@@ -25,7 +25,7 @@ public class CorsConfig {
 
     private CorsConfiguration corsConfiguration() {
         final CorsConfiguration corsConfiguration = new CorsConfiguration();
-        corsConfiguration.setAllowedOrigins(List.of(frontendProperties.baseUrl(), frontendProperties.localUrl()));
+        corsConfiguration.setAllowedOrigins(List.of(frontendProperties.baseUrl(), frontendProperties.localUrl(), frontendProperties.localSecureUrl()));
         corsConfiguration.setAllowedMethods(List.of("*"));
         corsConfiguration.setAllowedHeaders(List.of("*"));
         corsConfiguration.setAllowCredentials(true);

--- a/src/main/java/com/jobnote/global/config/properties/FrontendProperties.java
+++ b/src/main/java/com/jobnote/global/config/properties/FrontendProperties.java
@@ -9,7 +9,8 @@ public record FrontendProperties(
         String socialSignUpPage,
         String loginFailPage,
         String resetPasswordPage,
-        String localUrl
+        String localUrl,
+        String localSecureUrl
 ) {
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,7 @@ file:
 
 frontend:
   local-url: http://localhost:3000
+  local-secure-url: https://localhost:3000
   main-page: /dashboard
   login-fail-page: /login/fail
   social-sign-up-page: /join/nickname

--- a/src/test/java/com/jobnote/domain/applicationform/service/ApplicationFormServiceTest.java
+++ b/src/test/java/com/jobnote/domain/applicationform/service/ApplicationFormServiceTest.java
@@ -1,10 +1,15 @@
 package com.jobnote.domain.applicationform.service;
 
+import com.jobnote.ServiceUnitTest;
 import com.jobnote.domain.applicationform.domain.ApplicationForm;
+import com.jobnote.domain.applicationformdocument.repository.ApplicationFormDocumentRepository;
 import com.jobnote.domain.applicationform.repository.ApplicationFormRepository;
 import com.jobnote.domain.applicationform.dto.ApplicationFormRequest;
 import com.jobnote.domain.applicationform.dto.ApplicationFormResponse;
-import com.jobnote.domain.schedule.domain.ScheduleStatus;
+import com.jobnote.domain.applicationformdocument.service.ApplicationFormDocumentService;
+import com.jobnote.domain.document.domain.DocumentType;
+import com.jobnote.domain.document.dto.DocumentSimpleResponse;
+import com.jobnote.domain.document.service.DocumentService;
 import com.jobnote.domain.schedule.dto.ScheduleResponse;
 import com.jobnote.domain.schedule.service.ScheduleService;
 import com.jobnote.global.exception.JobNoteException;
@@ -14,10 +19,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -37,20 +40,28 @@ import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 
-@ExtendWith(MockitoExtension.class)
-class ApplicationFormServiceTest {
+class ApplicationFormServiceTest extends ServiceUnitTest {
 
     @InjectMocks
     private ApplicationFormService applicationFormService;
-
-    @Mock
-    private ApplicationFormRepository applicationFormRepository;
 
     @Mock
     private UserService userService;
 
     @Mock
     private ScheduleService scheduleService;
+
+    @Mock
+    private DocumentService documentService;
+
+    @Mock
+    private ApplicationFormDocumentService applicationFormDocumentService;
+
+    @Mock
+    private ApplicationFormRepository applicationFormRepository;
+
+    @Mock
+    private ApplicationFormDocumentRepository applicationFormDocumentRepository;
 
     private User user;
     private ApplicationForm applicationForm;
@@ -125,6 +136,48 @@ class ApplicationFormServiceTest {
         then(scheduleService).should().getAllGroupedByApplicationFormIds(eq(userId), eq(List.of(1L, 2L)));
     }
 
+    @Test
+    @DisplayName("지원서마다 문서들이 그룹핑되어 함께 반환된다")
+    void getAllApplicationForms_withDocuments() {
+        // given
+        ApplicationForm form1 = ApplicationForm.builder().user(user).companyName("네이버").status(APPLIED).build();
+        ApplicationForm form2 = ApplicationForm.builder().user(user).companyName("카카오").status(DOCUMENT_PASSED).build();
+        ReflectionTestUtils.setField(form1, "id", 1L);
+        ReflectionTestUtils.setField(form2, "id", 2L);
+        List<ApplicationForm> forms = List.of(form1, form2);
+
+        given(applicationFormRepository.findAllByUserId(userId)).willReturn(forms);
+
+        DocumentSimpleResponse document1 = new DocumentSimpleResponse(101L, DocumentType.RESUME, "네이버 이력서");
+        DocumentSimpleResponse document2 = new DocumentSimpleResponse(102L, DocumentType.COVER_LETTER, "네이버 자소서");
+        DocumentSimpleResponse document3 = new DocumentSimpleResponse(103L, DocumentType.RESUME, "카카오 이력서");
+
+        given(applicationFormDocumentService.getSimpleResponsesGroupedByApplicationFormIds(eq(userId), eq(List.of(1L, 2L))))
+                .willReturn(Map.of(
+                        1L, List.of(document1, document2),
+                        2L, List.of(document3)
+                ));
+
+        // when
+        List<ApplicationFormResponse> actualResult = applicationFormService.getAll(userId);
+
+        // then
+        assertThat(actualResult).hasSize(2);
+
+        ApplicationFormResponse result1 = actualResult.get(0);
+        assertThat(result1.companyName()).isEqualTo("네이버");
+        assertThat(result1.documents()).hasSize(2);
+        assertThat(result1.documents().get(0).title()).isEqualTo("네이버 이력서");
+
+        ApplicationFormResponse result2 = actualResult.get(1);
+        assertThat(result2.companyName()).isEqualTo("카카오");
+        assertThat(result2.documents()).hasSize(1);
+        assertThat(result2.documents().get(0).title()).isEqualTo("카카오 이력서");
+
+        then(applicationFormRepository).should().findAllByUserId(userId);
+        then(applicationFormDocumentService).should().getSimpleResponsesGroupedByApplicationFormIds(eq(userId), eq(List.of(1L, 2L)));
+    }
+
     @Nested
     @DisplayName("지원서 단건 조회")
     class GetById {
@@ -174,7 +227,7 @@ class ApplicationFormServiceTest {
     @Test
     void saveApplicationForm() {
         // given
-        ApplicationFormRequest request = new ApplicationFormRequest("네이버", "02-1234-7812", "경기도 성남시", null, null, null, null, null, APPLIED, null);
+        ApplicationFormRequest request = new ApplicationFormRequest("네이버", "02-1234-7812", "경기도 성남시", null, null, null, null, null, APPLIED, null, null);
         given(userService.getUserById(userId)).willReturn(user);
         given(applicationFormRepository.save(any(ApplicationForm.class))).willReturn(applicationForm);
 
@@ -188,7 +241,7 @@ class ApplicationFormServiceTest {
     @Nested
     @DisplayName("지원서 수정")
     class Update {
-        ApplicationFormRequest request = new ApplicationFormRequest("카카오", "02-1111-2222", "경기도 성남시", null, null, null, null, null, APPLIED, null);
+        ApplicationFormRequest request = new ApplicationFormRequest("카카오", "02-1111-2222", "경기도 성남시", null, null, null, null, null, APPLIED, null, null);
 
         @DisplayName("성공")
         @Test


### PR DESCRIPTION
## Resolved Issue
- close #45 

## PR Description
- 지원서에서 기등록된 문서를 연결할 수 있는 기능을 추가하였습니다.
- API 요청 예시
```json
get - http://localhost:8080/api/v1/application-forms
지원서에 어떤 문서가 등록되어 있는지 확인하는 API
{
    "code": "2000",
    "message": "요청이 성공적으로 처리되었습니다.",
    "details": null,
    "data": {
        "applicationForms": [
            {
                "id": 2,
                "companyName": "네이버",
                "...": "..."
                "schedules": [
                    {
                        "id": 2,
                        "...": "..."
                    }
                ],
                "documents": [
                    {
                        "id": 2,
                        "type": "RESUME",
                        "title": "이력서.pdf"
                    }
                ]
            },
            {
                "id": 3,
                "companyName": "카카오",
                "...": "..."
                "schedules": [
                    {
                        "id": 3,
                        "...": "..."
                    }
                ],
                "documents": [
                    {
                        "id": 2,
                        "type": "RESUME",
                        "title": "이력서.pdf"
                    }
                ]
            }
        ]
    }
}

get - http://localhost:8080/api/v1/documents
문서가 어느 지원서에 등록되어 있는지 확인하는 API
{
    "code": "2000",
    "message": "요청이 성공적으로 처리되었습니다.",
    "details": null,
    "data": {
        "documents": [
            {
                "id": 2,
                "type": "RESUME",
                "title": "이력서.pdf",
                "lastModifiedDate": "2025-08-27",
                "applicationForms": [
                    {
                        "id": 2,
                        "companyName": "네이버",
                        "companyAddress": "경기 성남시 분당구",
                        "status": "PLANNED"
                    },
                    {
                        "id": 3,
                        "companyName": "카카오",
                        "companyAddress": "경기 성남시 분당구",
                        "status": "PLANNED"
                    }
                ]
            }
        ]
    }
}
```

- 지원서(ApplicationForm)와 문서(Document) 양방향에서 모두 조회가 가능하여야 하기때문에 ManyToMany 구성이 필요하였고, 맵핑 엔티티를 생성하였습니다.(ApplicationFormDocument)
- DTO 반환 시 ApplicationFormSimpleResponse, DocumentSimpleResponse를 사용하여 순환 참조를 방지하였고, ApplicationFormDocumentService를 별도로 생성하여 관련 작업을 위임하였습니다.
- 지원서 CRUD시 연결 문서가 같이 포함되어 동작하도록 구성하였습니다. (이전의 지원서-일정 간 로직과 유사)

## Others
- 추후 리팩토링 : ApplicationFormDocumentService에서 getSimpleResponsesByApplicationFormId와 getSimpleResponsesGroupedByApplicationFormIds은 어느정도 코드를 공유하고, 또한 그룹핑해서 반환하는 코드도 편의를 위해 다른 서비스 계층에서 List.of(formId) 식으로 넘겨주는 것도 많은 상태입니다.
추후 일관성있게 코드를 개편할 필요가 있습니다.