### PR TITLE
config: 배포 자동화 워크플로 생성

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Set up Application Secret YML
         run: |
           echo "${{ secrets.APPLICATION_SECRET }}" | base64 --decode > src/main/resources/application-secret.yml
-          echo "${{ secrets.APPLICATION_SECRET_LOCAL }}" | base64 --decode > src/main/resources/application-secret-local.yml
           echo "${{ secrets.APPLICATION_SECRET_DEV }}" | base64 --decode > src/main/resources/application-secret-dev.yml
           mkdir -p src/main/resources/ssl
           echo "${{ secrets.KEYSTORE }}" | base64 --decode > src/main/resources/ssl/keystore.p12

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy Spring Boot Application To API Server
+
+on:
+  push:
+    branches: [ "dev" ]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+        
+      - name: Set up Application Secret YML
+        run: |
+          echo "${{ secrets.APPLICATION_SECRET }}" | base64 --decode > src/main/resources/application-secret.yml
+          echo "${{ secrets.APPLICATION_SECRET_LOCAL }}" | base64 --decode > src/main/resources/application-secret-local.yml
+          echo "${{ secrets.APPLICATION_SECRET_DEV }}" | base64 --decode > src/main/resources/application-secret-dev.yml
+          mkdir -p src/main/resources/ssl
+          echo "${{ secrets.KEYSTORE }}" | base64 --decode > src/main/resources/ssl/keystore.p12
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle Wrapper
+        run: ./gradlew build
+        
+      - name: Copy JAR to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.HOST }}
+          port: ${{ secrets.PORT }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.PRIVATE_KEY }}
+          source: "build/libs/*.jar"
+          target: "/home/ubuntu/app/"
+
+      - name: Restart Service
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.HOST }}
+          port: ${{ secrets.PORT }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.PRIVATE_KEY }}
+          script: |
+            sudo systemctl restart jobnote

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
         run: ./gradlew build
         
       - name: Copy JAR to server
-        uses: appleboy/scp-action@v0.1.7
+        uses: appleboy/scp-action@v1
         with:
           host: ${{ secrets.HOST }}
           port: ${{ secrets.PORT }}
@@ -43,7 +43,7 @@ jobs:
           target: "/home/ubuntu/app/"
 
       - name: Restart Service
-        uses: appleboy/ssh-action@v1.2.0
+        uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.HOST }}
           port: ${{ secrets.PORT }}


### PR DESCRIPTION
## Resolved Issue
- close #68 

## PR Description
- 배포 자동화 워크플로를 생성하였습니다.
- dev 브랜치에 push 시 build 및 jar파일이 서버로 전송되어 jobnote 서비스를 재시작하는 형태로 구동됩니다.
- 서버 접속에 필요한 host, port, username, key를 github secret에 등록하였고, keystore.p12(ssl 인증서 파일) 또한 base64로 인코딩하여 저장 후 resources에 포함되도록 하였습니다.

```yml
on:
  push:
    branches: [ "dev" ]

...

run: |
  mkdir -p src/main/resources/ssl
  echo "${{ secrets.KEYSTORE }}" | base64 --decode > src/main/resources/ssl/keystore.p12

...

- name: Build with Gradle Wrapper
  run: ./gradlew build

- name: Copy JAR to server
  uses: appleboy/scp-action@v0.1.7
  with:
    host: ${{ secrets.HOST }}
    port: ${{ secrets.PORT }}
    username: ${{ secrets.USERNAME }}
    key: ${{ secrets.PRIVATE_KEY }}
    source: "build/libs/*.jar"
    target: "/home/ubuntu/app/"

- name: Restart Service
  uses: appleboy/ssh-action@v1.2.0
  with:
    host: ${{ secrets.HOST }}
    port: ${{ secrets.PORT }}
    username: ${{ secrets.USERNAME }}
    key: ${{ secrets.PRIVATE_KEY }}
    script: |
      sudo systemctl restart jobnote

```

- jobnote 서비스는 다음과 같습니다.
```
#/etc/systemd/system/jobnote.service
[Unit]
Description=Jobnote Spring Boot Service
After=network.target
 
[Service]
#User=ubuntu
WorkingDirectory=/home/ubuntu/app
ExecStart=/usr/bin/java -Duser.timezone=Asia/Seoul -jar /home/ubuntu/app/build/libs/jobnote-0.0.1-SNAPSHOT.jar --spring.profiles.active=dev
SuccessExitStatus=143
Restart=on-failure
RestartSec=10
StandardOutput=journal
StandardError=journal
 
[Install]
WantedBy=multi-user.target
```

```
서비스 등록 : sudo systemctl daemon-reload
부팅 시 자동 시작 : sudo systemctl enable jobnote
서비스 시작 : sudo systemctl start jobnote
상태 확인 : sudo systemctl status jobnote, sudo journalctl -u jobnote.service -f
재시작 : sudo systemctl restart jobnote
```

## 추후 개선해야 될 사항
- 무중단 배포 필요성
- jar파일 버전명 하드코딩 문제
- 현재 443 HTTPS포트를 이용하고 있는 상황에서, 1024 이하의 포트는 root 권한이 필요하여 User을 주석 처리하여 root 권한으로 실행하였음(보안 문제?). 추후 nginx로 맵핑 필요성