### PR TITLE
feat: 회원 로직 수정

### DIFF
--- a/src/main/java/com/jobnote/auth/token/TokenProvider.java
+++ b/src/main/java/com/jobnote/auth/token/TokenProvider.java
@@ -63,7 +63,7 @@ public class TokenProvider {
     }
 
     public void addInvalidateCookie(final HttpServletResponse response) {
-        response.addHeader(HttpHeaders.SET_COOKIE, CookieUtil.invalidateCookie(COOKIE_NAME_ACCESS_TOKEN).toString());
-        response.addHeader(HttpHeaders.SET_COOKIE, CookieUtil.invalidateCookie(COOKIE_NAME_REFRESH_TOKEN).toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, CookieUtil.invalidateCookie(COOKIE_NAME_ACCESS_TOKEN, COOKIE_PATH_ACCESS_TOKEN).toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, CookieUtil.invalidateCookie(COOKIE_NAME_REFRESH_TOKEN, COOKIE_PATH_REFRESH_TOKEN).toString());
     }
 }

--- a/src/main/java/com/jobnote/domain/email/controller/VerificationEmailController.java
+++ b/src/main/java/com/jobnote/domain/email/controller/VerificationEmailController.java
@@ -38,6 +38,6 @@ public class VerificationEmailController {
     @GetMapping("/reset-password/verify")
     public void verifyResetPasswordEmail(@RequestParam("token") final String token, final HttpServletResponse response) throws IOException {
         verificationEmailService.verify(token);
-        response.sendRedirect(frontendProperties.baseUrl() + frontendProperties.resetPasswordPage());
+        response.sendRedirect(frontendProperties.baseUrl() + frontendProperties.resetPasswordPage() + "?token=" + token);
     }
 }

--- a/src/main/java/com/jobnote/global/common/ResponseCode.java
+++ b/src/main/java/com/jobnote/global/common/ResponseCode.java
@@ -36,6 +36,7 @@ public enum ResponseCode {
     PENDING_EMAIL_VERIFICATION(HttpStatus.FORBIDDEN, "4031", "이메일 인증이 완료되지 않았습니다."),
     NOT_YET_SIGNED_UP(HttpStatus.FORBIDDEN, "4032", "회원가입 절차가 완료되지 않았습니다."),
     VERIFICATION_EMAIL_NOT_YET_VERIFIED(HttpStatus.FORBIDDEN, "4033", "인증이 완료되지 않은 인증 이메일입니다."),
+    INACTIVE_USER(HttpStatus.FORBIDDEN, "4034", "탈퇴한 회원입니다."),
 
     // 404 Not Found
     NOT_FOUND(HttpStatus.NOT_FOUND, "4040", "요청 리소스를 찾을 수 없습니다."),

--- a/src/main/java/com/jobnote/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/jobnote/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.jobnote.global.common.ResponseCode;
 import com.jobnote.global.common.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -31,6 +32,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleHttpRequestMethodNotSupportedException(final HttpRequestMethodNotSupportedException e) {
         log.error("HttpRequestMethodNotSupportedException: ", e);
         ResponseCode responseCode = ResponseCode.METHOD_NOT_ALLOWED;
+        return new ResponseEntity<>(ApiResponse.ofFail(responseCode), responseCode.getStatus());
+    }
+
+    @ExceptionHandler(DisabledException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDisabledException(final DisabledException e) {
+        log.error("DisabledException: ", e);
+        ResponseCode responseCode = ResponseCode.INACTIVE_USER;
         return new ResponseEntity<>(ApiResponse.ofFail(responseCode), responseCode.getStatus());
     }
 

--- a/src/main/java/com/jobnote/global/util/CookieUtil.java
+++ b/src/main/java/com/jobnote/global/util/CookieUtil.java
@@ -33,7 +33,7 @@ public class CookieUtil {
                 .build();
     }
 
-    public static ResponseCookie invalidateCookie(final String name) {
-        return createResponseCookie(name, "", "/", Duration.ZERO);
+    public static ResponseCookie invalidateCookie(final String name, final String path) {
+        return createResponseCookie(name, "", path, Duration.ZERO);
     }
 }

--- a/src/test/java/com/jobnote/global/util/CookieUtilTest.java
+++ b/src/test/java/com/jobnote/global/util/CookieUtilTest.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseCookie;
 import java.time.Duration;
 
 import static com.jobnote.global.common.Constants.COOKIE_NAME_ACCESS_TOKEN;
+import static com.jobnote.global.common.Constants.COOKIE_PATH_ACCESS_TOKEN;
 import static com.jobnote.global.common.ResponseCode.INVALID_TOKEN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -54,7 +55,7 @@ class CookieUtilTest {
         // given
 
         // when
-        ResponseCookie responseCookie = CookieUtil.invalidateCookie(COOKIE_NAME_ACCESS_TOKEN);
+        ResponseCookie responseCookie = CookieUtil.invalidateCookie(COOKIE_NAME_ACCESS_TOKEN, COOKIE_PATH_ACCESS_TOKEN);
 
         // then
         assertThat(responseCookie.getValue()).isEmpty();


### PR DESCRIPTION
## Resolved Issue
- close #73

## PR Description
### 탈퇴한 회원의 요청 예외 처리
- 로그인 요청 시 CustomUserDetails의 isEnabled() 메서드에서 회원의 탈퇴 여부를 검사하고 있습니다. 이때 발생하는 DisabledException 예외를 처리하도록 구현했습니다.
```java
@RequiredArgsConstructor
public class CustomUserDetails implements UserDetails, OAuth2User {
  private final User user;
  @Override
  public boolean isEnabled() {
      return !user.isDeleted();
  }
}
```

### 비밀번호 초기화 리다이렉트 주소 수정
- 비밀번호 초기화 메일 인증 시 프론트엔드에 인증 메일의 token 값을 넘겨주도록 리다이렉트 주소를 수정했습니다.
```java
response.sendRedirect(frontendProperties.baseUrl() + frontendProperties.resetPasswordPage() + "?token=" + token);
```

### 쿠키 만료 설정 수정
- 쿠키 만료 시 path를 잘못 설정해 리프레시 토큰 쿠키가 삭제되지 않는 문제를 해결했습니다.
```java
// before
public static ResponseCookie invalidateCookie(final String name) {
    return createResponseCookie(name, "", "/", Duration.ZERO);
}

// after
public static ResponseCookie invalidateCookie(final String name, final String path) {
    return createResponseCookie(name, "", path, Duration.ZERO);
}
```

## Others
