### PR TITLE
feat: JWT 토큰 전달 방식 변경

### DIFF
--- a/src/main/java/com/jobnote/auth/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/jobnote/auth/filter/TokenAuthenticationFilter.java
@@ -64,8 +64,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
     private String validateAuthorizationHeader(final HttpServletRequest request) {
         final String header = request.getHeader(HttpHeaders.AUTHORIZATION);
-
-        if (StringUtils.hasText(header) || !header.startsWith(BEARER)) {
+        if (!StringUtils.hasText(header) || !header.startsWith(BEARER)) {
             throw new JobNoteException(INVALID_HEADER);
         }
 

--- a/src/main/java/com/jobnote/auth/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/jobnote/auth/filter/TokenAuthenticationFilter.java
@@ -12,17 +12,19 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
 import static com.jobnote.global.common.Constants.*;
+import static com.jobnote.global.common.ResponseCode.INVALID_HEADER;
 import static com.jobnote.global.common.ResponseCode.INVALID_TOKEN;
-import static com.jobnote.global.util.CookieUtil.getTokenFromCookie;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -47,7 +49,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private void authenticate(final HttpServletRequest request) {
-        final String email = tokenProvider.getEmailFromPayload(getTokenFromCookie(request.getCookies(), COOKIE_NAME_ACCESS_TOKEN))
+        final String accessToken = validateAuthorizationHeader(request);
+        final String email = tokenProvider.getEmailFromPayload(accessToken)
                 .orElseThrow(() -> new JobNoteException(INVALID_TOKEN));
 
         setAuthentication(email);
@@ -57,6 +60,16 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         CustomUserDetails principal = (CustomUserDetails) customUserDetailsService.loadUserByUsername(email);
         Authentication authenticationToken = new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+    }
+
+    private String validateAuthorizationHeader(final HttpServletRequest request) {
+        final String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (StringUtils.hasText(header) || !header.startsWith(BEARER)) {
+            throw new JobNoteException(INVALID_HEADER);
+        }
+
+        return header.substring(BEARER.length());
     }
 
     @Override

--- a/src/main/java/com/jobnote/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/jobnote/auth/handler/OAuth2LoginSuccessHandler.java
@@ -35,7 +35,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         }
 
         final Token token = authTokenService.saveAndGetToken(principal.getUserId());
-        tokenProvider.addTokenToCookie(response, token);
+        tokenProvider.responseToken(response, token);
 
         response.sendRedirect(memberRedirectUrl());
     }

--- a/src/main/java/com/jobnote/auth/token/TokenProvider.java
+++ b/src/main/java/com/jobnote/auth/token/TokenProvider.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 
 import static com.jobnote.global.common.Constants.*;
 import static com.jobnote.global.common.ResponseCode.EXPIRED_TOKEN;
-import static com.jobnote.global.util.CookieUtil.createResponseCookie;
 
 @RequiredArgsConstructor
 @Component
@@ -54,16 +53,13 @@ public class TokenProvider {
         }
     }
 
-    public void addTokenToCookie(final HttpServletResponse response, final Token token) {
-        ResponseCookie accessTokenCookie = createResponseCookie(COOKIE_NAME_ACCESS_TOKEN, token.accessToken(), COOKIE_PATH_ACCESS_TOKEN, Duration.ofMillis(jwtProvider.getJwtProperties().accessToken().expirationTime()));
-        ResponseCookie refreshTokenCookie = createResponseCookie(COOKIE_NAME_REFRESH_TOKEN, token.refreshToken(), COOKIE_PATH_REFRESH_TOKEN, Duration.ofMillis(jwtProvider.getJwtProperties().refreshToken().expirationTime()));
-
-        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+    public void responseToken(final HttpServletResponse response, final Token token) {
+        final ResponseCookie refreshTokenCookie = CookieUtil.createResponseCookie(COOKIE_NAME_REFRESH_TOKEN, token.refreshToken(), COOKIE_PATH_REFRESH_TOKEN, Duration.ofMillis(jwtProvider.getJwtProperties().refreshToken().expirationTime()));
+        response.setHeader(HttpHeaders.AUTHORIZATION, token.accessToken());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
     }
 
-    public void addInvalidateCookie(final HttpServletResponse response) {
-        response.addHeader(HttpHeaders.SET_COOKIE, CookieUtil.invalidateCookie(COOKIE_NAME_ACCESS_TOKEN, COOKIE_PATH_ACCESS_TOKEN).toString());
+    public void responseInvalidatedToken(final HttpServletResponse response) {
         response.addHeader(HttpHeaders.SET_COOKIE, CookieUtil.invalidateCookie(COOKIE_NAME_REFRESH_TOKEN, COOKIE_PATH_REFRESH_TOKEN).toString());
     }
 }

--- a/src/main/java/com/jobnote/domain/user/controller/UserController.java
+++ b/src/main/java/com/jobnote/domain/user/controller/UserController.java
@@ -18,7 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import static com.jobnote.global.common.Constants.COOKIE_NAME_REFRESH_TOKEN;
-import static com.jobnote.global.util.CookieUtil.getTokenFromCookie;
+import static com.jobnote.global.util.CookieUtil.getValueFromCookie;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
@@ -55,7 +55,7 @@ public class UserController {
     /* LOGOUT */
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(final HttpServletRequest request, final HttpServletResponse response) {
-        authTokenService.invalidate(getTokenFromCookie(request.getCookies(), COOKIE_NAME_REFRESH_TOKEN));
+        authTokenService.invalidate(getValueFromCookie(request.getCookies(), COOKIE_NAME_REFRESH_TOKEN));
         tokenProvider.responseInvalidatedToken(response);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }
@@ -63,7 +63,7 @@ public class UserController {
     /* TOKEN REISSUE */
     @PostMapping("/reissue")
     public ResponseEntity<ApiResponse<Void>> tokenReissue(@LoginUser CustomUserDetails principal, final HttpServletRequest request, final HttpServletResponse response) {
-        final Token token = authTokenService.reissue(principal.getUserId(), getTokenFromCookie(request.getCookies(), COOKIE_NAME_REFRESH_TOKEN));
+        final Token token = authTokenService.reissue(principal.getUserId(), getValueFromCookie(request.getCookies(), COOKIE_NAME_REFRESH_TOKEN));
         tokenProvider.responseToken(response, token);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }

--- a/src/main/java/com/jobnote/domain/user/controller/UserController.java
+++ b/src/main/java/com/jobnote/domain/user/controller/UserController.java
@@ -40,7 +40,7 @@ public class UserController {
     @PostMapping("/signup/social")
     public ResponseEntity<ApiResponse<Void>> socialSignUp(@RequestBody @Valid final SocialSignUpRequest request, final HttpServletResponse response) {
         final Token token = userService.socialSignUp(request);
-        tokenProvider.addTokenToCookie(response, token);
+        tokenProvider.responseToken(response, token);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }
 
@@ -48,7 +48,7 @@ public class UserController {
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<Void>> login(@RequestBody @Valid final UserLoginRequest request, final HttpServletResponse response) {
         final Token token = loginService.login(request);
-        tokenProvider.addTokenToCookie(response, token);
+        tokenProvider.responseToken(response, token);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }
 
@@ -56,7 +56,7 @@ public class UserController {
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(final HttpServletRequest request, final HttpServletResponse response) {
         authTokenService.invalidate(getTokenFromCookie(request.getCookies(), COOKIE_NAME_REFRESH_TOKEN));
-        tokenProvider.addInvalidateCookie(response);
+        tokenProvider.responseInvalidatedToken(response);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }
 
@@ -64,7 +64,7 @@ public class UserController {
     @PostMapping("/reissue")
     public ResponseEntity<ApiResponse<Void>> tokenReissue(@LoginUser CustomUserDetails principal, final HttpServletRequest request, final HttpServletResponse response) {
         final Token token = authTokenService.reissue(principal.getUserId(), getTokenFromCookie(request.getCookies(), COOKIE_NAME_REFRESH_TOKEN));
-        tokenProvider.addTokenToCookie(response, token);
+        tokenProvider.responseToken(response, token);
         return ResponseEntity.ok(ApiResponse.ofSuccess(ResponseCode.OK));
     }
 

--- a/src/main/java/com/jobnote/global/common/Constants.java
+++ b/src/main/java/com/jobnote/global/common/Constants.java
@@ -4,6 +4,8 @@ import java.util.Set;
 
 public abstract class Constants {
 
+    public static final String BEARER = "Bearer ";
+
     // claim
     public static final String CLAIM_NAME_TOKEN_TYPE = "token";
     public static final String CLAIM_NAME_EMAIL = "email";

--- a/src/main/java/com/jobnote/global/common/ResponseCode.java
+++ b/src/main/java/com/jobnote/global/common/ResponseCode.java
@@ -20,6 +20,7 @@ public enum ResponseCode {
     INVALID_TOKEN_TYPE(HttpStatus.BAD_REQUEST, "4004", "올바르지 않은 토큰 타입입니다."),
     VERIFICATION_EMAIL_ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "4005", "이미 인증이 완료된 인증 이메일입니다."),
     INVALID_HEADER(HttpStatus.BAD_REQUEST, "4006", "헤더가 올바르지 않습니다."),
+    INVALID_COOKIE(HttpStatus.BAD_REQUEST, "4007", "쿠키가 올바르지 않습니다."),
 
     // 401 Unauthorized
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "4010", "요청 리소스에 대한 액세스 권한이 없습니다."),

--- a/src/main/java/com/jobnote/global/common/ResponseCode.java
+++ b/src/main/java/com/jobnote/global/common/ResponseCode.java
@@ -19,6 +19,7 @@ public enum ResponseCode {
     NOT_SUPPORTED_SOCIAL_PROVIDER(HttpStatus.BAD_REQUEST, "4003", "해당 소셜 로그인은 지원되지 않습니다."),
     INVALID_TOKEN_TYPE(HttpStatus.BAD_REQUEST, "4004", "올바르지 않은 토큰 타입입니다."),
     VERIFICATION_EMAIL_ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "4005", "이미 인증이 완료된 인증 이메일입니다."),
+    INVALID_HEADER(HttpStatus.BAD_REQUEST, "4006", "헤더가 올바르지 않습니다."),
 
     // 401 Unauthorized
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "4010", "요청 리소스에 대한 액세스 권한이 없습니다."),

--- a/src/main/java/com/jobnote/global/util/CookieUtil.java
+++ b/src/main/java/com/jobnote/global/util/CookieUtil.java
@@ -11,7 +11,7 @@ import static com.jobnote.global.common.ResponseCode.INVALID_COOKIE;
 
 public class CookieUtil {
 
-    public static String getTokenFromCookie(final Cookie[] cookies, final String name) {
+    public static String getValueFromCookie(final Cookie[] cookies, final String name) {
         if (cookies == null) {
             throw new JobNoteException(INVALID_COOKIE);
         }

--- a/src/main/java/com/jobnote/global/util/CookieUtil.java
+++ b/src/main/java/com/jobnote/global/util/CookieUtil.java
@@ -7,19 +7,19 @@ import org.springframework.http.ResponseCookie;
 import java.time.Duration;
 import java.util.Arrays;
 
-import static com.jobnote.global.common.ResponseCode.INVALID_TOKEN;
+import static com.jobnote.global.common.ResponseCode.INVALID_COOKIE;
 
 public class CookieUtil {
 
     public static String getTokenFromCookie(final Cookie[] cookies, final String name) {
         if (cookies == null) {
-            throw new JobNoteException(INVALID_TOKEN);
+            throw new JobNoteException(INVALID_COOKIE);
         }
 
         return Arrays.stream(cookies)
                 .filter(cookie -> name.equals(cookie.getName()))
                 .findFirst()
-                .orElseThrow(() -> new JobNoteException(INVALID_TOKEN))
+                .orElseThrow(() -> new JobNoteException(INVALID_COOKIE))
                 .getValue();
     }
 

--- a/src/test/java/com/jobnote/auth/LoginApplicationTest.java
+++ b/src/test/java/com/jobnote/auth/LoginApplicationTest.java
@@ -6,11 +6,11 @@ import com.jobnote.domain.user.dto.UserLoginRequest;
 import com.jobnote.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.ResultActions;
 
-import static com.jobnote.global.common.Constants.COOKIE_NAME_ACCESS_TOKEN;
 import static com.jobnote.global.common.Constants.COOKIE_NAME_REFRESH_TOKEN;
 import static com.jobnote.global.common.ResponseCode.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -51,7 +51,7 @@ class LoginApplicationTest extends JobnoteApplicationTests {
                 // then
                 resultActions
                         .andExpect(status().isForbidden())
-                        .andExpect(cookie().doesNotExist(COOKIE_NAME_ACCESS_TOKEN))
+                        .andExpect(header().doesNotExist(HttpHeaders.AUTHORIZATION))
                         .andExpect(cookie().doesNotExist(COOKIE_NAME_REFRESH_TOKEN))
                         .andExpect(jsonPath("$.data").isEmpty())
                         .andExpect(jsonPath("$.code").value(PENDING_EMAIL_VERIFICATION.getCode()));
@@ -72,7 +72,7 @@ class LoginApplicationTest extends JobnoteApplicationTests {
                 // then
                 resultActions
                         .andExpect(status().isOk())
-                        .andExpect(cookie().exists(COOKIE_NAME_ACCESS_TOKEN))
+                        .andExpect(header().exists(HttpHeaders.AUTHORIZATION))
                         .andExpect(cookie().exists(COOKIE_NAME_REFRESH_TOKEN));
             }
         }
@@ -100,7 +100,7 @@ class LoginApplicationTest extends JobnoteApplicationTests {
                 // then
                 resultActions
                         .andExpect(status().isUnauthorized())
-                        .andExpect(cookie().doesNotExist(COOKIE_NAME_ACCESS_TOKEN))
+                        .andExpect(header().doesNotExist(HttpHeaders.AUTHORIZATION))
                         .andExpect(cookie().doesNotExist(COOKIE_NAME_REFRESH_TOKEN))
                         .andExpect(jsonPath("$.data").isEmpty())
                         .andExpect(jsonPath("$.code").value(INVALID_USERNAME_PASSWORD.getCode()));
@@ -122,7 +122,7 @@ class LoginApplicationTest extends JobnoteApplicationTests {
                 // then
                 resultActions
                         .andExpect(status().isUnauthorized())
-                        .andExpect(cookie().doesNotExist(COOKIE_NAME_ACCESS_TOKEN))
+                        .andExpect(header().doesNotExist(HttpHeaders.AUTHORIZATION))
                         .andExpect(cookie().doesNotExist(COOKIE_NAME_REFRESH_TOKEN))
                         .andExpect(jsonPath("$.data").isEmpty())
                         .andExpect(jsonPath("$.code").value(INVALID_USERNAME_PASSWORD.getCode()));

--- a/src/test/java/com/jobnote/global/util/CookieUtilTest.java
+++ b/src/test/java/com/jobnote/global/util/CookieUtilTest.java
@@ -11,7 +11,7 @@ import java.time.Duration;
 
 import static com.jobnote.global.common.Constants.COOKIE_NAME_ACCESS_TOKEN;
 import static com.jobnote.global.common.Constants.COOKIE_PATH_ACCESS_TOKEN;
-import static com.jobnote.global.common.ResponseCode.INVALID_TOKEN;
+import static com.jobnote.global.common.ResponseCode.INVALID_COOKIE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -45,7 +45,7 @@ class CookieUtilTest {
             // when & then
             assertThatThrownBy(() -> CookieUtil.getTokenFromCookie(cookies, COOKIE_NAME_ACCESS_TOKEN))
                     .isInstanceOf(JobNoteException.class)
-                    .hasMessage(INVALID_TOKEN.getMessage());
+                    .hasMessage(INVALID_COOKIE.getMessage());
         }
     }
 

--- a/src/test/java/com/jobnote/global/util/CookieUtilTest.java
+++ b/src/test/java/com/jobnote/global/util/CookieUtilTest.java
@@ -30,7 +30,7 @@ class CookieUtilTest {
             Cookie[] cookies = new Cookie[]{new Cookie(COOKIE_NAME_ACCESS_TOKEN, accessToken)};
 
             // when
-            String result = CookieUtil.getTokenFromCookie(cookies, COOKIE_NAME_ACCESS_TOKEN);
+            String result = CookieUtil.getValueFromCookie(cookies, COOKIE_NAME_ACCESS_TOKEN);
 
             // then
             assertThat(result).isEqualTo(accessToken);
@@ -43,7 +43,7 @@ class CookieUtilTest {
             Cookie[] cookies = new Cookie[]{};
 
             // when & then
-            assertThatThrownBy(() -> CookieUtil.getTokenFromCookie(cookies, COOKIE_NAME_ACCESS_TOKEN))
+            assertThatThrownBy(() -> CookieUtil.getValueFromCookie(cookies, COOKIE_NAME_ACCESS_TOKEN))
                     .isInstanceOf(JobNoteException.class)
                     .hasMessage(INVALID_COOKIE.getMessage());
         }


### PR DESCRIPTION
## Resolved Issue
- close #75 

## PR Description
### 액세스 토큰 전달 방식 변경
- 기존 쿠키로 전달하던 것을 Authorization 헤더로 전달하도록 변경했습니다.
- 쿠키로 전달 시 만료되면 자동으로 삭제되어 재발급하기 어려웠던 문제를 해결했습니다.
- 토큰 검증 시에는 표준화된 방식인 Bearer 인증 방식을 사용했습니다.

### CookieUtil 클래스 메서드명 및 예외 메시지 변경
- getTokenFromCookie 메서드가 토큰 뿐만 아니라 쿠키의 값을 꺼낸다는 더 넓은 범위의 메서드로 사용되도록 변경했습니다.
- 예외 메시지 또한 클라이언트에서 쿠키가 문제라는 명확한 메시지를 받을 수 있도록 수정했습니다.

```java
// before
public static String getTokenFromCookie(final Cookie[] cookies, final String name) {
    if (cookies == null) {
        throw new JobNoteException(INVALID_TOKEN);
    }

    return Arrays.stream(cookies)
            .filter(cookie -> name.equals(cookie.getName()))
            .findFirst()
            .orElseThrow(() -> new JobNoteException(INVALID_TOKEN))
            .getValue();
}

// after
public static String getValueFromCookie(final Cookie[] cookies, final String name) {
    if (cookies == null) {
        throw new JobNoteException(INVALID_COOKIE);
    }

    return Arrays.stream(cookies)
            .filter(cookie -> name.equals(cookie.getName()))
            .findFirst()
            .orElseThrow(() -> new JobNoteException(INVALID_COOKIE))
            .getValue();
}
```

## Others
