### PR TITLE
feat: Swagger 인증 버튼 추가

### DIFF
--- a/src/main/java/com/jobnote/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/jobnote/global/config/swagger/SwaggerConfig.java
@@ -1,8 +1,11 @@
 package com.jobnote.global.config.swagger;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import jakarta.annotation.PostConstruct;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springdoc.core.utils.SpringDocUtils;
@@ -14,6 +17,7 @@ import io.swagger.v3.oas.models.Operation;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -24,7 +28,19 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization")
+                .scheme("bearer")
+                .bearerFormat("JWT");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
+
         return new OpenAPI()
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                .security(List.of(securityRequirement))
                 .info(info());
     }
 


### PR DESCRIPTION
## Resolved Issue
- close #79

## PR Description
- #76 에 따른 Swagger API 명세서에 인증 버튼을 추가하여 편리하게 API 호출 테스트를 할 수 있도록 기능을 추가하였습니다.

<img width="1681" height="451" alt="제목 없음" src="https://github.com/user-attachments/assets/89fe5490-a37a-4d41-85aa-53b906189725" />
- /login 에서 로그인 요청 후 Response headers에서 authorization 복사
<img width="1786" height="340" alt="image" src="https://github.com/user-attachments/assets/89a6f8ce-4e26-45eb-9eb0-e7b85951494a" />
- 우측 상단의 Authorize 버튼 클릭
<img width="787" height="349" alt="image" src="https://github.com/user-attachments/assets/d919d78b-07eb-4232-b46d-3b1f4f9901af" />
- Value에 값 붙여넣기 후 Authorize 버튼 클릭
<img width="793" height="351" alt="image" src="https://github.com/user-attachments/assets/2107d185-136a-4cf1-9c3a-a6671fc436c7" />
- 인증 등록 완료
<img width="1701" height="547" alt="image" src="https://github.com/user-attachments/assets/8eb62a2d-00de-4ec2-ae06-a096532dcaeb" />
- 요청 테스트 완료


