### PR TITLE
fix: 지원서-문서 연결 업데이트 오류 수정

### DIFF
--- a/src/main/java/com/jobnote/domain/applicationformdocument/dto/ApplicationFormDocumentRequest.java
+++ b/src/main/java/com/jobnote/domain/applicationformdocument/dto/ApplicationFormDocumentRequest.java
@@ -6,10 +6,8 @@ import com.jobnote.domain.document.domain.Document;
 import jakarta.validation.constraints.NotNull;
 
 public record ApplicationFormDocumentRequest(
-        Long id,
-
         @NotNull(message = "문서 ID는 null일 수 없습니다.")
-        Long documentId
+        Long id
 ) {
     public ApplicationFormDocument toEntity(final ApplicationForm form, final Document document) {
         return ApplicationFormDocument.builder()

--- a/src/main/java/com/jobnote/domain/applicationformdocument/service/ApplicationFormDocumentService.java
+++ b/src/main/java/com/jobnote/domain/applicationformdocument/service/ApplicationFormDocumentService.java
@@ -69,7 +69,7 @@ public class ApplicationFormDocumentService {
     @Transactional
     public void saveAll(final Long userId, final ApplicationForm form, final List<ApplicationFormDocumentRequest> requests) {
         for (ApplicationFormDocumentRequest request : requests) {
-            Document document = getByIdOrThrow(request.documentId());
+            Document document = getByIdOrThrow(request.id());
             document.validateOwner(userId);
 
             ApplicationFormDocument entity = request.toEntity(form, document);
@@ -82,6 +82,9 @@ public class ApplicationFormDocumentService {
     public void updateAll(final Long userId, final ApplicationForm form, final List<ApplicationFormDocumentRequest> requests) {
         // 기존 연결된 문서 조회
         List<ApplicationFormDocument> existsDocuments = getAllByApplicationFormId(userId, form.getId());
+        Set<Long> existsIds =  existsDocuments.stream()
+                .map(document -> document.getDocument().getId())
+                .collect(Collectors.toSet());
 
         // 요청 문서 ID 목록
         Set<Long> requestsIds = requests.stream()
@@ -91,14 +94,14 @@ public class ApplicationFormDocumentService {
 
         // 삭제 : 기존 문서 중 요청에 없는 문서 삭제
         for (ApplicationFormDocument document : existsDocuments) {
-            if (!requestsIds.contains(document.getId())) {
+            if (!requestsIds.contains(document.getDocument().getId())) {
                 delete(document);
             }
         }
 
-        // 신규 생성
+        // 신규 생성 : 새로운 id
         for (ApplicationFormDocumentRequest req : requests) {
-            if (req.id() == null) {
+            if (!existsIds.contains(req.id())) {
                 saveAll(userId, form, List.of(req));
             }
         }


### PR DESCRIPTION
## Resolved Issue
- close #91 

## PR Description
```diff
public record ApplicationFormDocumentRequest(
        Long id,
-       Long documentId
)
```
- 기존에 지원서-문서 연결 요청 Dto에서 불필요하게 id값을 2개 받아 업데이트 코드가 잘못 구현된 문제를 해결하였습니다.

요청 예시
get /documents
```json
{
	"id": 5,
	"type": "RESUME",
	"title": "배민 이력서",
	"lastModifiedDate": "2025-09-02",
	"latestVersion": 1,
	"applicationForms": []
},
{
	"id": 6,
	"type": "RESUME",
	"title": "네이버 이력서",
	"lastModifiedDate": "2025-09-02",
	"latestVersion": 1,
	"applicationForms": []
},
{
	"id": 7,
	"type": "RESUME",
	"title": "카카오 이력서",
	"lastModifiedDate": "2025-09-02",
	"latestVersion": 2,
	"applicationForms": []
},
{
	"id": 8,
	"type": "RESUME",
	"title": "쿠팡 이력서",
	"lastModifiedDate": "2025-09-02",
	"latestVersion": 3,
	"applicationForms": []
}
```

post /application-forms
```json
{
  "companyName": "네이버",
  "companyAddress": "경기도",
  "companyUrl": "naver.com",
  "companyScale": "대기업",
  "position": "백엔드 개발자",
  "status": "PLANNED",
  "documents": [
    {
      "id": 5
    },
    {
      "id": 6
    }
  ]
}
```

get /application-forms/1
```json
{
	"id": 1,
	"companyName": "네이버",
	"companyAddress": "경기도",
	"companyUrl": "naver.com",
	"companyScale": "대기업",
	"position": "백엔드 개발자",
	"status": "PLANNED",
	"schedules": [],
	"documents": [
		{
			"id": 5,
			"type": "RESUME",
			"title": "배민 이력서"
		},
		{
			"id": 6,
			"type": "RESUME",
			"title": "네이버 이력서"
		}
	]
}
```

이 상태에서
5(배민 이력서)는 유지
6(네이버 이력서)는 삭제
7(카카오 이력서), 8(쿠팡 이력서)를 추가하고 싶다면

put /application-forms/1
```json
{
	"companyName": "네이버",
	"companyAddress": "경기도",
	"companyUrl": "naver.com",
	"companyScale": "대기업",
	"position": "백엔드 개발자",
	"status": "PLANNED",
	"schedules": [],
	"documents": [
		{
			"id": 5
		},
		{
			"id": 7
		},
		{
			"id": 8
		}
	]
}
```

get /application-forms/1
```json
{
	"id": 1,
	"companyName": "네이버",
	"companyAddress": "경기도",
	"companyUrl": "naver.com",
	"companyScale": "대기업",
	"position": "백엔드 개발자",
	"status": "PLANNED",
	"schedules": [],
	"documents": [
		{
			"id": 5,
			"type": "RESUME",
			"title": "배민 이력서"
		},
		{
			"id": 7,
			"type": "RESUME",
			"title": "카카오 이력서"
		},
		{
			"id": 8,
			"type": "RESUME",
			"title": "쿠팡 이력서"
		}
	]
}
```