### PR TITLE
fix: 문서 수정일 미변경 오류, 문서버전별 업로드 날짜 반환 추가

### DIFF
--- a/src/main/java/com/jobnote/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/jobnote/domain/common/BaseTimeEntity.java
@@ -21,4 +21,8 @@ public abstract class BaseTimeEntity {
 
     @LastModifiedDate
     private LocalDateTime modifiedDate;
+
+    public void updateModifiedDate(final LocalDateTime modifiedDate) {
+        this.modifiedDate = modifiedDate;
+    }
 }

--- a/src/main/java/com/jobnote/domain/document/dto/DocumentVersionResponse.java
+++ b/src/main/java/com/jobnote/domain/document/dto/DocumentVersionResponse.java
@@ -4,6 +4,8 @@ import com.jobnote.domain.document.domain.DocumentVersion;
 import lombok.AccessLevel;
 import lombok.Builder;
 
+import java.time.LocalDate;
+
 @Builder(access = AccessLevel.PRIVATE)
 public record DocumentVersionResponse(
     Long id,
@@ -11,7 +13,8 @@ public record DocumentVersionResponse(
     String title,
     String fileName,
     String fileUrl,
-    Long fileSize
+    Long fileSize,
+    LocalDate createdDate
 ) {
     public static DocumentVersionResponse of(final DocumentVersion documentVersion, final String fileUrl) {
         return DocumentVersionResponse.builder()
@@ -21,6 +24,7 @@ public record DocumentVersionResponse(
                 .fileName(documentVersion.getOriginFileName())
                 .fileUrl(fileUrl)
                 .fileSize(documentVersion.getFileSize())
+                .createdDate(documentVersion.getCreatedDate().toLocalDate())
                 .build();
     }
 }

--- a/src/main/java/com/jobnote/domain/document/service/DocumentService.java
+++ b/src/main/java/com/jobnote/domain/document/service/DocumentService.java
@@ -18,6 +18,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 import static com.jobnote.global.common.ResponseCode.NOT_FOUND_DOCUMENT;
 
 @Service
@@ -44,6 +46,7 @@ public class DocumentService {
     public Long uploadNewVersionDocument(final Long userId, final Long documentId, final DocumentRequest request) {
         Document document = getByIdOrThrow(documentId);
         document.validateOwner(userId);
+        document.updateModifiedDate(LocalDateTime.now());
 
         int version = documentVersionRepository.findLatestVersionByDocumentId(documentId) + 1;
 


### PR DESCRIPTION
## Resolved Issue
- close #97 

## PR Description
- 문서 새로운 버전 업로드 시 Document의 lastModifiedDate도 업데이트 되도록 변경하였습니다.
- 문서 버전 목록 반환 시 각 버전의 업로드 날짜를 포함하도록 반환하도록 추가하였습니다.